### PR TITLE
fix(docs): remove repo_type from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,6 @@ html_title = "commit-check"
 html_theme_options = {
     "repo_url": "https://github.com/commit-check/commit-check",
     "repo_name": "commit-check",
-    "repo_type": "github",
     "palette": [
         {
             "media": "(prefers-color-scheme: light)",


### PR DESCRIPTION
Build docs failed because `repo_type` was removed. see https://github.com/jbms/sphinx-immaterial/issues/259