### PR TITLE
Create attestations for the final package

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,6 +30,11 @@ jobs:
         # Check distribution
         twine check dist/commit_check*
 
+    - name: Create attestations
+    - uses: actions/attest-build-provenance@v1
+      with:
+        subject-path: "dist/commit_check*"
+
     - name: Generate subject
       id: hash
       run: |


### PR DESCRIPTION
It looks like GitHub rolled out their own attestations in beta. I wonder if we could integrate with that. for more details below:

- https://github.com/actions/attest-build-provenance
- https://github.com/orgs/community/discussions/122028
- https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds
- https://github.blog/2024-04-30-where-does-your-software-really-come-from/