### PR TITLE
Drop python 3.7 and support 3.13.0-beta.1 in main CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        py: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13.0-beta.1']
         os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Fixed the failure in main CI.

```bash
Run actions/setup-python@v5
Installed versions
  Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'arm64' was not found for macOS 14.5.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```