### PR TITLE
fix: update publish_dir to fix online docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,14 +54,16 @@ jobs:
       fail-fast: false
       matrix:
         py: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        os: ['windows-latest', 'ubuntu-latest', 'macos-latest']
+        os: ['windows-latest', 'ubuntu-24.04', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.py }}
-      - run: pip install -r requirements-dev.txt
+      - run: |
+          pip install --upgrade pip
+          pip install -r requirements-dev.txt
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v4
@@ -100,4 +102,4 @@ jobs:
           uses: peaceiris/actions-gh-pages@v4
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
-            publish_dir: ./docs/_build/html
+            publish_dir: ./_build/html

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,6 @@
 # and commit this file to your remote git repository to share the goodness with others.
 
 tasks:
-  - before: pip install -r requirements-dev.txt
+  - before: pip install --upgrade pip && pip install -r requirements-dev.txt
     init: pre-commit install
     command: pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = {text = "MIT License"}
 authors = [
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },
 ]
+requires-python = ">=3.8"
 dependencies = ["pyyaml"]
 classifiers = [
     # https://pypi.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
* fix online docs
* update os to ubuntu-24.04 to fix warning 
* update pip to the latest version to fix the warning on MacOS with Python3.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Ubuntu 24.04
	- Updated Gitpod configuration to upgrade pip before installing dependencies
	- Updated project configuration to require Python 3.8+ and add PyYAML dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->