### PR TITLE
fix: allow accented letters in author name

### DIFF
--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -32,7 +32,7 @@ DEFAULT_CONFIG = {
         },
         {
             'check': 'author_name',
-            'regex': r'^[A-Za-z ,.\'-]+$|.*(\[bot])',
+            'regex': r'^[A-Za-zÀ-ÖØ-öø-ÿĀ-ž\u0100-\u017F\u0180-\u024F ,.\'-]+$|.*(\[bot])',
             'error': 'The committer name seems invalid',
             'suggest': 'run command `git config user.name "Your Name"`',
         },

--- a/tests/author_test.py
+++ b/tests/author_test.py
@@ -9,6 +9,7 @@ class TestAuthor:
     class TestAuthorName:
         # used by get_commit_info mock
         fake_author_value_an = "fake_author_name"
+        fake_accented_author_value_an = "fáké_áúthór_námé"
 
         def test_check_author(self, mocker):
             # Must call get_commit_info, re.match.
@@ -19,6 +20,25 @@ class TestAuthor:
             m_get_commit_info = mocker.patch(
                 f"{LOCATION}.get_commit_info",
                 return_value=self.fake_author_value_an
+            )
+            m_re_match = mocker.patch(
+                "re.match",
+                return_value="fake_rematch_resp"
+            )
+            retval = check_author(checks, "author_name")
+            assert retval == PASS
+            assert m_get_commit_info.call_count == 1
+            assert m_re_match.call_count == 1
+
+        def test_check_author_with_accented_letters(self, mocker):
+            # Must call get_commit_info, re.match.
+            checks = [{
+                "check": "author_name",
+                "regex": "dummy_regex"
+            }]
+            m_get_commit_info = mocker.patch(
+                f"{LOCATION}.get_commit_info",
+                return_value=self.fake_accented_author_value_an
             )
             m_re_match = mocker.patch(
                 "re.match",


### PR DESCRIPTION
Allow accented letters (e.g. áéó, etc.) in an author's name. I think this is quite commonplace (e.g. my name contains accented letters).

Since Python doesn't allow Unicode character class matching this needs to be added to the existing regex:

```[À-ÖØ-öø-ÿĀ-ž\u0100-\u017F\u0180-\u024F]```

This matches the following ranges:
À-Ö → Matches uppercase Latin letters with diacritics from À (U+00C0) to Ö (U+00D6).
Ø-ö → Matches uppercase Ø (U+00D8) to lowercase ö (U+00F6).
ø-ÿ → Matches lowercase ø (U+00F8) to ÿ (U+00FF).
Ā-ž → Matches Latin Extended-A characters from Ā (U+0100) to ž (U+017F).
\u0100-\u017F → Explicitly specifies the same range as Ā-ž in Unicode notation.
\u0180-\u024F → Matches Latin Extended-B characters, covering additional accented and special Latin characters.

This covers quite a lot I think. Also, I don't there is an argument over *not* having something like the default, hence the PR, or is there?