### PR TITLE
feat: allow emojis (gitmoji) in messages

### DIFF
--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG = {
     'checks': [
         {
             'check': 'message',
-            'regex': r'^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\U0001F600-\U0001F64F\U0001F300-\U0001F5FF\U0001F680-\U0001F6FF\U0001F700-\U0001F77F\U0001F780-\U0001F7FF\U0001F800-\U0001F8FF\U0001F900-\U0001F9FF\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\u2600-\u26FF\u2700-\u27BF] )?([\w ])+([\s\S]*)|(Merge).*|(fixup!.*)',
+            'regex': r'^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\u2600-\u26FF\u2700-\u27BF\U0001F000-\U0001F02F\U0001F0A0-\U0001F0FF\U0001F100-\U0001F1FF\U0001F300-\U0001F5FF\U0001F600-\U0001F64F\U0001F680-\U0001F6FF\U0001F900-\U0001F9FF]\uFE0F? )?([\w ])+([\s\S]*)|(Merge).*|(fixup!.*)',
             'error': 'The commit message should be structured as follows:\n\n'
             '<type>[optional scope]: <description>\n'
             '[optional body]\n'

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -16,7 +16,7 @@ DEFAULT_CONFIG = {
     'checks': [
         {
             'check': 'message',
-            'regex': r'^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\w ])+([\s\S]*)|(Merge).*|(fixup!.*)',
+            'regex': r'^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\([\w\-\.]+\))?(!)?: ([\U0001F600-\U0001F64F\U0001F300-\U0001F5FF\U0001F680-\U0001F6FF\U0001F700-\U0001F77F\U0001F780-\U0001F7FF\U0001F800-\U0001F8FF\U0001F900-\U0001F9FF\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF\u2600-\u26FF\u2700-\u27BF] )?([\w ])+([\s\S]*)|(Merge).*|(fixup!.*)',
             'error': 'The commit message should be structured as follows:\n\n'
             '<type>[optional scope]: <description>\n'
             '[optional body]\n'

--- a/tests/commit_test.py
+++ b/tests/commit_test.py
@@ -48,6 +48,7 @@ def test_check_commit_msg_no_commit_msg_file(mocker):
     mock_read_commit_msg.assert_called_once_with(".git/COMMIT_EDITMSG")
     assert result == 0
 
+
 def test_check_commit_msg_with_emoji_commit_msg_file_using_defaults(mocker):
     mock_get_default_commit_msg_file = mocker.patch(
         "commit_check.commit.get_default_commit_msg_file",
@@ -56,6 +57,25 @@ def test_check_commit_msg_with_emoji_commit_msg_file_using_defaults(mocker):
     mock_read_commit_msg = mocker.patch(
         "commit_check.commit.read_commit_msg",
         return_value="fix: 🐛 sample"
+    )
+
+    checks = [next(c for c in DEFAULT_CONFIG['checks'] if c['check'] == 'message')]
+
+    result = check_commit_msg(checks, commit_msg_file="")
+
+    mock_get_default_commit_msg_file.assert_called_once()
+    mock_read_commit_msg.assert_called_once_with(".git/COMMIT_EDITMSG")
+    assert result == 0
+
+
+def test_check_commit_msg_with_grapheme_cluster_emoji_commit_msg_file_using_defaults(mocker):
+    mock_get_default_commit_msg_file = mocker.patch(
+        "commit_check.commit.get_default_commit_msg_file",
+        return_value=".git/COMMIT_EDITMSG"
+    )
+    mock_read_commit_msg = mocker.patch(
+        "commit_check.commit.read_commit_msg",
+        return_value="docs: 📚️ mention commit-check and rulesets" # watch out emoji is U+1F4DA followed by U+FE0F
     )
 
     checks = [next(c for c in DEFAULT_CONFIG['checks'] if c['check'] == 'message')]

--- a/tests/commit_test.py
+++ b/tests/commit_test.py
@@ -1,4 +1,4 @@
-from commit_check import PASS, FAIL
+from commit_check import PASS, FAIL, DEFAULT_CONFIG
 from commit_check.commit import check_commit_msg, get_default_commit_msg_file, read_commit_msg, check_commit_signoff
 
 # used by get_commit_info mock
@@ -41,6 +41,24 @@ def test_check_commit_msg_no_commit_msg_file(mocker):
     )
 
     checks = [{"regex": ".*", "check": "message", "error": "Invalid", "suggest": None}]
+
+    result = check_commit_msg(checks, commit_msg_file="")
+
+    mock_get_default_commit_msg_file.assert_called_once()
+    mock_read_commit_msg.assert_called_once_with(".git/COMMIT_EDITMSG")
+    assert result == 0
+
+def test_check_commit_msg_with_emoji_commit_msg_file_using_defaults(mocker):
+    mock_get_default_commit_msg_file = mocker.patch(
+        "commit_check.commit.get_default_commit_msg_file",
+        return_value=".git/COMMIT_EDITMSG"
+    )
+    mock_read_commit_msg = mocker.patch(
+        "commit_check.commit.read_commit_msg",
+        return_value="fix: 🐛 sample"
+    )
+
+    checks = [next(c for c in DEFAULT_CONFIG['checks'] if c['check'] == 'message')]
 
     result = check_commit_msg(checks, commit_msg_file="")
 


### PR DESCRIPTION
To allow commit messages like `refactor: ♻️ don't use a monorepo` and so I use [devmoji](https://github.com/folke/devmoji) a tool to automate and ease [gitmoji](https://gitmoji.dev/) usage.

However the default regex doesn't allow emojis in the message. I'm not sure whether this is an oversight or that the conventional commit "spec" (if it is a spec) says that this not allowed.

If it doesn't *disallow* this I would wager it can be allowed, hence my PR.

Since Python `re` doesn't support using `\p{Emoji}` I added a long messy character class in `__init__.py`.

If it could considered to update to [`regex`](https://pypi.org/project/regex/) this long regex could be shortened considerable ... not sure it's worth the effort tho' and the extra dependency to manage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded commit message validation to support a broader range of characters, including emojis and various symbols.

- **Tests**
	- Added tests to verify that commit messages containing emojis are properly validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->