### PR TITLE
chore: drop unsupported python version 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        py: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        py: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: ['windows-latest', 'ubuntu-24.04', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = {text = "MIT License"}
 authors = [
     { name = "Xianpeng Shen", email = "xianpeng.shen@gmail.com" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = ["pyyaml"]
 classifiers = [
     # https://pypi.org/pypi?%3Aaction=list_classifiers
@@ -20,8 +20,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
see https://devguide.python.org/versions/#unsupported-versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported Python versions to require Python 3.9 and above, ensuring compatibility with modern environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->