### PR TITLE
Potential fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: main
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check/security/code-scanning/45](https://github.com/commit-check/commit-check/security/code-scanning/45)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, such as `actions/checkout`, `actions/upload-artifact`, and `peaceiris/actions-gh-pages`, the workflow requires `contents: read` and `contents: write` permissions. Additionally, the `codecov/codecov-action` step requires access to repository secrets, so no additional permissions are needed for that step.

The `permissions` block will be added at the top of the workflow file, applying to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to improve repository content management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->