### PR TITLE
fix: Potential fix Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
       - "main"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   draft-release:
     uses: commit-check/.github/.github/workflows/release-drafter.yml@main


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check/security/code-scanning/43](https://github.com/commit-check/commit-check/security/code-scanning/43)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the context, the workflow likely needs read access to repository contents and write access to pull requests (if it drafts releases based on pull requests). 

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`draft-release`) to limit permissions for that job only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configuration to specify repository and pull request permissions for GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->