### PR TITLE
fix: potential fix workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,5 +1,8 @@
 name: publish image
 
+permissions:
+  contents: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check/security/code-scanning/42](https://github.com/commit-check/commit-check/security/code-scanning/42)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow interacts with Docker images and uses the `secrets.CR_PAT` for authentication, it likely only needs `contents: read` permissions to access the repository's files.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `publish` job to limit permissions specifically for that job. In this case, adding it at the root level is recommended for simplicity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow permissions for improved security in automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->