### PR TITLE
fix: potential fix workflow does not contain permissions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,9 @@
 name: PR Autolabeler
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   # pull_request event is required for autolabeler
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check/security/code-scanning/40](https://github.com/commit-check/commit-check/security/code-scanning/40)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Since the workflow is using `release-drafter.yml`, it likely requires read access to repository contents and possibly write access to pull requests. We will set `contents: read` and `pull-requests: write` as the permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
