### PR TITLE
fix: use `git branch --show-current` to get branch name

### DIFF
--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -22,7 +22,8 @@ def get_branch_name() -> str:
     :returns: A `str` describing the current branch name.
     """
     try:
-        commands = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+        # Git 2.22 and above supports `git branch --show-current`
+        commands = ['git', 'branch', '--show-current']
         branch_name = cmd_output(commands)
     except CalledProcessError:
         branch_name = ''

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -25,7 +25,7 @@ class TestUtil:
             retval = get_branch_name()
             assert m_cmd_output.call_count == 1
             assert m_cmd_output.call_args[0][0] == [
-                "git", "rev-parse", "--abbrev-ref", "HEAD"
+                "git", "branch", "--show-current"
             ]
             assert retval == "fake_branch_name"
 
@@ -45,7 +45,7 @@ class TestUtil:
             retval = get_branch_name()
             assert m_cmd_output.call_count == 1
             assert m_cmd_output.call_args[0][0] == [
-                "git", "rev-parse", "--abbrev-ref", "HEAD"
+                "git", "branch", "--show-current"
             ]
             assert retval == ""
 


### PR DESCRIPTION
closes #249 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer versions of Git when retrieving the current branch name.

* **Tests**
  * Updated tests to align with the new method of fetching the current branch name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->