### PR TITLE
fix: add package write permission

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,6 +2,7 @@ name: publish image
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
closes #247 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to improve support for publishing Docker images to the GitHub Container Registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->