### PR TITLE
fix(message): protect the message regex check

### DIFF
--- a/commit_check/commit.py
+++ b/commit_check/commit.py
@@ -38,13 +38,13 @@ def check_commit_msg(checks: list, commit_msg_file: str = "") -> int:
     commit_msg = read_commit_msg(commit_msg_file)
 
     for check in checks:
-        if check['regex'] == "":
-            print(
-                f"{YELLOW}Not found regex for commit message. skip checking.{RESET_COLOR}",
-            )
-            return PASS
-
         if check['check'] == 'message':
+            if check['regex'] == "":
+                print(
+                    f"{YELLOW}Not found regex for commit message. skip checking.{RESET_COLOR}",
+                )
+                return PASS
+
             result = re.match(check['regex'], commit_msg)
             if result is None:
                 if not print_error_header.has_been_called:


### PR DESCRIPTION
Protect the "regex" key check by first verifying that the check type is "message". Previously check_commit_msg was verifying that all check configuration structures had valid regex keys. This is unnecessary and does not follow the pattern of other checks.