### PR TITLE
fix: update regex to support breaking changes

### DIFF
--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -200,7 +200,8 @@ class SubjectImperativeValidator(SubjectValidator):
         # Extract first word (ignore conventional commit prefixes)
         import re
 
-        match = re.match(r"^(?:\w+(?:\([^)]*\))?[!:]?\s*)?(\w+)", subject)
+        # support breaking changes (feat!:)
+        match = re.match(r"^(?:\w+(?:\([^)]*\))?!?:\s*)?(\w+)", subject)
         if not match:
             return ValidationResult.PASS
 

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -778,3 +778,23 @@ class TestSubjectImperativeValidator:
         # "add" is a valid imperative word with conventional prefix
         result = validator.validate(context)
         assert result == ValidationResult.PASS
+
+    def test_validate_with_breaking_change(self):
+        """Test validation with breaking change notation."""
+        rule = ValidationRule(check="imperative")
+        validator = SubjectImperativeValidator(rule)
+        context = ValidationContext(stdin_text="feat!: update authentication system")
+
+        # "update" is a valid imperative word with breaking change notation
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS
+
+    def test_validate_with_scoped_breaking_change(self):
+        """Test validation with scoped breaking change notation."""
+        rule = ValidationRule(check="imperative")
+        validator = SubjectImperativeValidator(rule)
+        context = ValidationContext(stdin_text="fix(auth)!: resolve login bug")
+
+        # "resolve" is a valid imperative word with scope and breaking change notation
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS


### PR DESCRIPTION
closes #301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Commit subject validation now recognizes breaking-change notation in conventional commits (e.g., feat!:, fix(scope)!). Expanded prefix handling; behavior for other subjects remains unchanged. No changes to public interfaces or runtime behavior.
* **Tests**
  * Added coverage for breaking-change and scoped breaking-change subjects to confirm they are accepted by the validator, improving confidence in commit-check compatibility with common formatting patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->