### PR TITLE
feat: support additional `allow_branch_names` in configuration

### DIFF
--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -41,6 +41,8 @@ DEFAULT_BRANCH_TYPES = [
     "feat",
     "fix",
 ]
+# Additional allowed branch names (e.g., develop, staging)
+DEFAULT_BRANCH_NAMES: list[str] = []
 
 # Handle different default values for different rules
 DEFAULT_BOOLEAN_RULES = {

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -112,7 +112,7 @@ BRANCH_RULES = [
         check="branch",
         regex=None,  # Built dynamically from config
         error="The branch should follow Conventional Branch. See https://conventional-branch.github.io/",
-        suggest="Use <type>/<description> with allowed types or ignore_authors in config branch section to bypass",
+        suggest="Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass",
     ),
     RuleCatalogEntry(
         check="merge_base",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -45,6 +45,7 @@ Example Configuration
     # https://conventional-branch.github.io/
     conventional_branch = true
     allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+    # allow_branch_names = []  # Optional - additional standalone branch names (e.g., ["develop", "staging"])
     # require_rebase_target = "main"  # Optional - no rebase requirement by default
     # ignore_authors = []      # Optional - no authors ignored by default
 
@@ -140,6 +141,11 @@ Options Table Description
      - list[str]
      - ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
      - Allowed branch types when conventional_branch is true.
+   * - branch
+     - allow_branch_names
+     - list[str]
+     - [] (empty list)
+     - Additional standalone branch names allowed when conventional_branch is true (e.g., ["develop", "staging"]). By default, master, main, HEAD, and PR-* are always allowed.
    * - branch
      - require_rebase_target
      - str

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -197,8 +197,67 @@ class TestBranchValidator:
         validator = BranchValidator(rule)
         context = ValidationContext(stdin_text="feature/new-feature")
 
+        validator.validate(context)
+
+    @patch("commit_check.engine.has_commits")
+    @patch("commit_check.engine.get_branch_name")
+    @pytest.mark.benchmark
+    def test_branch_validator_develop_branch_allowed(
+        self, mock_get_branch_name, mock_has_commits
+    ):
+        """Test BranchValidator with develop branch when it's in allow_branch_names."""
+        mock_has_commits.return_value = True
+        mock_get_branch_name.return_value = "develop"
+        # Regex pattern that includes develop as an allowed branch name
+        rule = ValidationRule(
+            check="branch",
+            regex=r"^(feature|bugfix|hotfix)\/.+|(master)|(main)|(HEAD)|(PR-.+)|(develop)",
+        )
+        validator = BranchValidator(rule)
+        config = {"branch": {"ignore_authors": []}}
+        context = ValidationContext(config=config)
         result = validator.validate(context)
         assert result == ValidationResult.PASS
+
+    @patch("commit_check.engine.has_commits")
+    @patch("commit_check.engine.get_branch_name")
+    @pytest.mark.benchmark
+    def test_branch_validator_staging_branch_allowed(
+        self, mock_get_branch_name, mock_has_commits
+    ):
+        """Test BranchValidator with staging branch when it's in allow_branch_names."""
+        mock_has_commits.return_value = True
+        mock_get_branch_name.return_value = "staging"
+        # Regex pattern that includes staging as an allowed branch name
+        rule = ValidationRule(
+            check="branch",
+            regex=r"^(feature|bugfix|hotfix)\/.+|(master)|(main)|(HEAD)|(PR-.+)|(staging)|(develop)",
+        )
+        validator = BranchValidator(rule)
+        config = {"branch": {"ignore_authors": []}}
+        context = ValidationContext(config=config)
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS
+
+    @patch("commit_check.engine.has_commits")
+    @patch("commit_check.engine.get_branch_name")
+    @pytest.mark.benchmark
+    def test_branch_validator_develop_branch_not_allowed(
+        self, mock_get_branch_name, mock_has_commits
+    ):
+        """Test BranchValidator with develop branch when it's NOT in allow_branch_names."""
+        mock_has_commits.return_value = True
+        mock_get_branch_name.return_value = "develop"
+        # Regex pattern that does NOT include develop as an allowed branch name
+        rule = ValidationRule(
+            check="branch",
+            regex=r"^(feature|bugfix|hotfix)\/.+|(master)|(main)|(HEAD)|(PR-.+)",
+        )
+        validator = BranchValidator(rule)
+        config = {"branch": {"ignore_authors": []}}
+        context = ValidationContext(config=config)
+        result = validator.validate(context)
+        assert result == ValidationResult.FAIL
 
     @pytest.mark.benchmark
     def test_validate_without_regex(self):


### PR DESCRIPTION
closes #335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to specify additional custom branch names allowed when using conventional branch validation rules.

* **Documentation**
  * Updated configuration documentation with details and examples for the new branch name allowlist feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->