### PR TITLE
fix: move write permission from workflow level to job level

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: main
 
-permissions:
-  contents: write
-
 on:
   push:
     branches:
@@ -85,6 +82,8 @@ jobs:
 
   docs:
       runs-on: ubuntu-24.04
+      permissions:
+        contents: write
       steps:
         - uses: actions/checkout@v6.0.1
         - uses: actions/setup-python@v6.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the CI/CD workflow configuration with improved permissions management practices and controls. Repository write access is now scoped exclusively to specific jobs that require it, while all other workflow jobs operate with appropriately restricted access permissions to strengthen the overall security posture and minimize unnecessary risk exposure in automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->