### PR TITLE
fix: workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ on:
       - "!docs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/commit-check/commit-check/security/code-scanning/49](https://github.com/commit-check/commit-check/security/code-scanning/49)

To fix the problem, define explicit `permissions` for the workflow so the `GITHUB_TOKEN` is limited to the minimum required scopes. Since the `build` job uses `actions/checkout`, `upload-artifact`, and `codecov`, and the `docs` job already has its own `permissions` block, we can set a conservative default at the workflow root (e.g., `contents: read`) that applies to all jobs except those with their own overrides. The `install` job doesn’t need write access and can safely rely on the root `permissions: contents: read`.

The single best fix, without changing existing functionality, is:
- Add a `permissions:` block near the top of `.github/workflows/main.yml` at the workflow root level (same level as `on:` and `jobs:`), setting `contents: read`.
- Leave the `docs` job’s existing `permissions: contents: write` intact so it can still publish to GitHub Pages.
No extra imports or dependencies are needed; this is purely a YAML configuration change.

Concretely:
- In `.github/workflows/main.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (line 14–15 area), before `jobs:`. This will satisfy CodeQL and enforce least‑privilege defaults for `build` and `install` while preserving the `docs` job’s explicit permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
