### PR TITLE
docs: update hook ID to 'check-message' in configuration examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ For one-off checks or CI/CD pipelines, you can configure via CLI arguments or en
       - repo: https://github.com/commit-check/commit-check
         rev: v2.3.0
         hooks:
-          - id: commit-check
+          - id: check-message
             args:
               - --subject-imperative=false
               - --subject-max-length=100

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -123,7 +123,7 @@ The primary use case for CLI arguments is configuring commit-check in ``.pre-com
       - repo: https://github.com/commit-check/commit-check
         rev: v2.3.0
         hooks:
-          - id: commit-check
+          - id: check-message
             args:
               - --subject-imperative=false
               - --subject-max-length=100


### PR DESCRIPTION
Address https://github.com/commit-check/commit-check/pull/357#discussion_r2751904574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-commit hook configuration documentation to reflect the latest hook identifier naming conventions in configuration examples and setup guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->