### PR TITLE
docs: improve Why Commit Check comparison table

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -444,7 +444,7 @@ reflects a DIY approach rather than built-in product features.
    :widths: 26 16 16 16 26
 
    * - Feature
-     - Commit Check ✅
+     - Commit Check
      - commitlint
      - YACC [#f2]_
      - Custom hooks

--- a/README.rst
+++ b/README.rst
@@ -441,37 +441,45 @@ reflects a DIY approach rather than built-in product features.
 
 .. list-table::
    :header-rows: 1
-   :widths: 36 18 18 28
+   :widths: 26 16 16 16 26
 
    * - Feature
      - Commit Check ✅
      - commitlint
+     - YACC [#f2]_
      - Custom hooks
    * - Conventional Commits enforcement
      - ✅
      - ✅
+     - Partial
      - DIY
    * - Branch naming validation
      - ✅
      - ❌
+     - ✅
      - DIY
    * - Force push blocking
      - ✅
+     - ❌
      - ❌
      - DIY
    * - Author name / email validation
      - ✅
      - ❌
+     - ✅
      - DIY
    * - Signed-off-by trailer enforcement
      - ✅
-     - ✅
+     - Partial [#f1]_
+     - ❌
      - DIY
    * - Co-author ignore list
      - ✅
      - ❌
+     - Partial [#f3]_
      - DIY
    * - Organization-level shared config
+     - ✅
      - ✅
      - ✅
      - DIY
@@ -479,27 +487,70 @@ reflects a DIY approach rather than built-in product features.
      - ✅
      - ❌
      - ❌
+     - ❌
    * - Works without Node.js
      - ✅
      - ❌
+     - ✅
      - Depends
    * - Native TOML configuration
      - ✅
+     - ❌
      - ❌
      - Depends
    * - Git hook / pre-commit integration
      - ✅
      - Partial
+     - ❌
      - ✅
    * - CI/CD-friendly configuration
      - ✅
      - Partial
+     - ❌
      - DIY
+   * - Open source & free
+     - ✅
+     - ✅
+     - ❌
+     - ✅
+   * - Client-side (pre-commit) enforcement
+     - ✅
+     - ✅
+     - ❌
+     - ✅
+   * - AI-native (JSON API + Python SDK)
+     - ✅
+     - ❌
+     - ❌
+     - ❌
 
-For ``commitlint``, organization-level shared config is typically delivered via
-shareable config packages or local files. ``DIY`` means you can implement a
+*For* ``commitlint``, organization-level shared config is typically delivered via
+shareable config packages or local files.
+
+*For* ``YACC`` (Yet Another Commit Checker), conventional commit enforcement
+is regex-based rather than Conventional Commits-aware; author validation
+verifies committer name/email against Bitbucket user accounts or custom regex;
+the plugin supports global → project → repository config inheritance;
+it is a server-side pre-receive hook and merge check (no client-side
+pre-commit), is paid (per-user licensing), and runs on Java (no Node.js needed).
+
+``DIY`` means you can implement a
 capability with custom Git hooks or ``pre-commit`` scripts, but it is not
 provided as a turnkey policy layer.
+
+.. [#f1] ``commitlint`` provides a community ``signed-off-by`` rule
+   (``@commitlint/rule-signed-off-by``) that must be installed and configured
+   separately; it is not part of the default
+   ``@commitlint/config-conventional`` preset.
+
+.. [#f2] `Yet Another Commit Checker
+   <https://marketplace.atlassian.com/apps/1211854/yet-another-commit-checker>`_
+   is a paid Bitbucket Server / Data Center plugin (server-side pre-receive hook
+   and merge check).
+
+.. [#f3] YACC can exclude commits from specific Bitbucket users, user groups,
+   or service users (bots), but does not parse ``Co-authored-by:`` trailers
+   in commit messages.
 
 
 Versioning


### PR DESCRIPTION
## Summary

Improves the "Why Commit Check?" comparison table in README.rst:

### Changes
1. **Fix commitlint signed-off-by**: Changed from ✅ to `Partial` because `signed-off-by` requires the community `@commitlint/rule-signed-off-by` plugin — not part of `@commitlint/config-conventional`. Added footnote `[#f1]`.

2. **Add YACC (Yet Another Commit Checker) column**: YACC is already mentioned in the Overview as a tool commit-check is an alternative to. Adding it to the comparison table provides a complete competitive landscape. Footnote `[#f2]` explains its context.

3. **Add 3 new comparison rows**:
   - Open source & free
   - Client-side (pre-commit) enforcement
   - AI-native (JSON API + Python SDK)

### Verification
All Commit Check ✅ entries verified against source code (`rules_catalog.py`, `engine.py`, `rule_builder.py`, `api.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the feature comparison table with detailed information and improved layout structure for clearer feature comparison across options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/commit-check/commit-check/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->