### PR TITLE
docs: mention SchemaStore IDE autocompletion support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,14 @@ To customize the behavior, create a configuration file named ``cchk.toml`` or ``
     conventional_branch = true
     allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
 
+.. tip::
+  **IDE Autocompletion**
+
+  commit-check's TOML schema is published on `SchemaStore <https://www.schemastore.org/>`_,
+  so editors like VS Code (via `Even Better TOML <https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml>`_),
+  PyCharm, and IntelliJ provide autocompletion, validation, and documentation
+  tooltips for ``cchk.toml`` out of the box — no manual schema path configuration needed.
+
 Organization-Level Configuration (inherit_from)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,6 +46,14 @@ commit-check searches for configuration files in the following order (first foun
 
   Placing configuration files in the ``.github`` folder helps keep your repository root clean and follows GitHub conventions used by tools like Dependabot and Renovate.
 
+.. tip::
+  **IDE Autocompletion**
+
+  commit-check's TOML schema is published on `SchemaStore <https://www.schemastore.org/>`_,
+  so editors like VS Code (via `Even Better TOML <https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml>`_),
+  PyCharm, and IntelliJ provide autocompletion, validation, and documentation
+  tooltips for ``cchk.toml`` out of the box — no manual schema path configuration needed.
+
 Organization-Level Configuration (inherit_from)
 -------------------------------------------------
 


### PR DESCRIPTION
## Summary

commit-check's TOML schema has been accepted into [SchemaStore](https://www.schemastore.org/) ([SchemaStore/schemastore#5820](https://github.com/SchemaStore/schemastore/pull/5820)) — the well-known schema catalog that VS Code, PyCharm, IntelliJ, and other editors query for autocompletion and validation.

## Changes

Added a `.. tip::` note in two places:

- **`README.rst`** — in the Configuration → Use Custom Configuration File section, right after the example `cchk.toml` block
- **`docs/configuration.rst`** — in the Configuration File Locations section, after the GitHub Best Practice tip

The tip lets users know that they get IDE autocompletion and validation for `cchk.toml` out of the box, with no manual schema path configuration needed.