### PR TITLE
feat: add AI agent branch prefixes from conventional branch spec v1.1.0

### DIFF
--- a/cchk.toml
+++ b/cchk.toml
@@ -18,5 +18,7 @@ ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "code
 [branch]
 # https://conventional-branch.github.io/
 conventional_branch = true
+# Explicit list needed until AI agent prefixes are in a released version of commit-check
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
 require_rebase_target = "main"
 ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]

--- a/cchk.toml
+++ b/cchk.toml
@@ -18,6 +18,5 @@ ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "code
 [branch]
 # https://conventional-branch.github.io/
 conventional_branch = true
-allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
 require_rebase_target = "main"
 ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]

--- a/cchk.toml
+++ b/cchk.toml
@@ -18,6 +18,6 @@ ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "code
 [branch]
 # https://conventional-branch.github.io/
 conventional_branch = true
-allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "copilot"]
+allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "ai", "claude", "codex", "copilot", "cursor"]
 require_rebase_target = "main"
 ignore_authors = ["dependabot[bot]", "copilot[bot]", "pre-commit-ci[bot]", "shenxianpeng"]

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -31,7 +31,7 @@ DEFAULT_COMMIT_TYPES = [
     "build",
     "ci",
 ]
-# Follow conventional branch (https://conventional-branch.github.io/)
+# Follow conventional branch (https://conventionalbranch.org/)
 # Includes AI agent prefixes added in spec v1.1.0
 DEFAULT_BRANCH_TYPES = [
     "feature",

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -31,7 +31,8 @@ DEFAULT_COMMIT_TYPES = [
     "build",
     "ci",
 ]
-# Follow conventional branch
+# Follow conventional branch (https://conventional-branch.github.io/)
+# Includes AI agent prefixes added in spec v1.1.0
 DEFAULT_BRANCH_TYPES = [
     "feature",
     "bugfix",
@@ -40,6 +41,12 @@ DEFAULT_BRANCH_TYPES = [
     "chore",
     "feat",
     "fix",
+    # AI agent prefixes (conventional branch spec v1.1.0)
+    "ai",
+    "claude",
+    "codex",
+    "copilot",
+    "cursor",
 ]
 # Additional allowed branch names (e.g., develop, staging)
 DEFAULT_BRANCH_NAMES: list[str] = []

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -216,6 +216,35 @@ class TestRuleBuilder:
         assert "(PR-.+)" in rule.regex
 
     @pytest.mark.benchmark
+    def test_ai_agent_branch_types_in_default(self):
+        """AI agent prefixes from conventional branch spec v1.1.0 are valid by default."""
+        import re
+        from commit_check import DEFAULT_BRANCH_TYPES
+
+        assert "ai" in DEFAULT_BRANCH_TYPES
+        assert "claude" in DEFAULT_BRANCH_TYPES
+        assert "codex" in DEFAULT_BRANCH_TYPES
+        assert "copilot" in DEFAULT_BRANCH_TYPES
+        assert "cursor" in DEFAULT_BRANCH_TYPES
+
+        config = {"branch": {"conventional_branch": True}}
+        builder = RuleBuilder(config)
+        catalog_entry = RuleCatalogEntry(check="branch", regex="", error="", suggest="")
+        rule = builder._build_conventional_branch_rule(catalog_entry)
+        assert rule is not None
+
+        ai_agent_branches = [
+            "ai/refactor-auth-flow",
+            "claude/stoic-hypatia-v65p1f",
+            "claude/fix-login-bug",
+            "codex/optimize-query",
+            "copilot/add-login-page",
+            "cursor/fix-header-bug",
+        ]
+        for branch in ai_agent_branches:
+            assert re.match(rule.regex, branch), f"Branch '{branch}' should be valid"
+
+    @pytest.mark.benchmark
     def test_rule_builder_allow_branch_names_with_duplicates(self):
         """Test RuleBuilder with duplicate branch names in allow_branch_names."""
         config = {


### PR DESCRIPTION
## Summary

Closes #435

The [conventional branch spec v1.1.0](https://github.com/conventional-branch/conventional-branch/commit/36e3a381a0f64ff8048ccb72993e2b633ee34553) introduced five new branch prefixes for AI coding agents. This PR adds them to `DEFAULT_BRANCH_TYPES` so they are recognized as valid out of the box.

**New prefixes added:**
- `ai/` — generic AI agent
- `claude/` — Anthropic Claude Code
- `codex/` — OpenAI Codex
- `copilot/` — GitHub Copilot
- `cursor/` — Cursor IDE

**Example valid branches after this change:**
```
ai/refactor-auth-flow
claude/stoic-hypatia-v65p1f
codex/optimize-query
copilot/add-login-page
cursor/fix-header-bug
```

## Changes

- `commit_check/__init__.py`: Add 5 AI agent prefixes to `DEFAULT_BRANCH_TYPES`
- `tests/rule_builder_test.py`: Add `test_ai_agent_branch_types_in_default` to verify all new prefixes are present in defaults and that concrete AI agent branch names pass the regex

## Test plan

- [x] All 21 existing tests in `rule_builder_test.py` pass
- [x] New test covers all 5 AI agent prefixes and 6 concrete branch name examples

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAUwT2quqXxSA7WTYsdNaA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for AI agent branch type prefixes (ai, claude, codex, copilot, cursor) in conventional branch naming conventions.

* **Tests**
  * Added comprehensive verification for AI agent branch type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->