### PR TITLE
chore: remove dead CONFIG_FILE constant from __init__.py

### DIFF
--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -73,5 +73,4 @@ DEFAULT_BOOLEAN_RULES = {
 }
 
 
-CONFIG_FILE = "."  # Search current directory for commit-check.toml or cchk.toml
 __version__ = version("commit-check")


### PR DESCRIPTION
## Summary

Removes the `CONFIG_FILE = "."` constant from `commit_check/__init__.py`. This constant was defined but never imported or referenced anywhere in the codebase.

## Context

In the recent code review, this was flagged as dead code:

> `CONFIG_FILE = "."` defines but has never been used meaningfully (config.py has its own `DEFAULT_CONFIG_PATHS`). Can be removed.

Config file discovery is handled entirely by `config.py` via its own `DEFAULT_CONFIG_PATHS`, not by `CONFIG_FILE`.

## Changes
- `commit_check/__init__.py`: removed the `CONFIG_FILE` constant (1 line deletion)

## Testing
All CI checks (ruff, mypy, codespell, pre-commit hooks) pass.