### PR TITLE
fix: remove global state from print_error_header decorator

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,10 +5,11 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  pull-requests: write
-  contents: read
+permissions: {}
 
 jobs:
   draft-release:
+    permissions:
+      pull-requests: write
+      contents: read
     uses: commit-check/.github/.github/workflows/pr-labeler.yml@main

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,11 +5,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions: {}
+permissions:
+  pull-requests: write
+  contents: read
 
 jobs:
   draft-release:
-    permissions:
-      pull-requests: write
-      contents: read
     uses: commit-check/.github/.github/workflows/pr-labeler.yml@main

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -78,6 +78,9 @@ class BaseValidator(ABC):
         # Set by ValidationEngine.validate_all() from ValidationContext flags.
         self._no_banner: bool = False
         self._compact: bool = False
+        # Tracks whether the ASCII banner has been printed during this run.
+        # Reset by ValidationEngine before each batch of validation runs.
+        self._banner_printed: bool = False
         # Populated by _print_failure() on every failure, regardless of mode.
         self._last_failure: dict[str, str] | None = None
 
@@ -195,7 +198,12 @@ class BaseValidator(ABC):
         }
 
         if not self._suppress_output:
-            from commit_check.util import _print_failure
+            from commit_check.util import _print_failure, print_error_header
+
+            # Print the ASCII banner at most once per engine run.
+            if not self._no_banner and not self._compact and not self._banner_printed:
+                print_error_header()
+                self._banner_printed = True
 
             _print_failure(
                 rule_dict,
@@ -709,10 +717,14 @@ class ValidationEngine:
 
     def __init__(self, rules: list[ValidationRule]):
         self.rules = rules
+        # Tracks whether the ASCII banner has been printed during this run.
+        # Reset on every call to validate_all / validate_all_detailed.
+        self.banner_printed: bool = False
 
     def validate_all(self, context: ValidationContext) -> ValidationResult:
         """Run all validations and return overall result."""
         results = []
+        self.banner_printed = False
 
         for rule in self.rules:
             validator_class = self.VALIDATOR_MAP.get(rule.check)
@@ -722,7 +734,9 @@ class ValidationEngine:
             validator: BaseValidator = validator_class(rule)
             validator._no_banner = context.no_banner
             validator._compact = context.compact
+            validator._banner_printed = self.banner_printed
             result = validator.validate(context)
+            self.banner_printed = validator._banner_printed
             results.append(result)
 
         # Return FAIL if any validation failed
@@ -748,6 +762,7 @@ class ValidationEngine:
             failed = [o for o in outcomes if o.status == "fail"]
         """
         outcomes: list[CheckOutcome] = []
+        self.banner_printed = False
 
         for rule in self.rules:
             validator_class = self.VALIDATOR_MAP.get(rule.check)
@@ -756,7 +771,9 @@ class ValidationEngine:
 
             validator: BaseValidator = validator_class(rule)
             validator._suppress_output = True  # collect, don't print
+            validator._banner_printed = self.banner_printed
             result = validator.validate(context)
+            self.banner_printed = validator._banner_printed
 
             if result == ValidationResult.FAIL:
                 failure = validator._last_failure or {}

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -503,11 +503,6 @@ def main() -> int:
         if not args.message:
             stdin_content = _resolve_stdin_for_non_message(args, stdin_reader)
 
-        # Reset banner state for this run
-        from commit_check.util import print_error_header as _peh
-
-        _peh.has_been_called = False
-
         context = ValidationContext(
             stdin_text=stdin_content,
             commit_file=commit_file_path,

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -31,7 +31,7 @@ def _print_failure(
         compact_value = actual.splitlines()[0] if actual else actual
         print(f"[FAIL] {check['check']}: {compact_value}")
         return
-    if not no_banner and not print_error_header.has_been_called:
+    if not no_banner:
         print_error_header()
     print_error_message(check["check"], check.get("error", ""), actual)
     if check.get("suggest"):
@@ -263,16 +263,6 @@ def cmd_output(commands: list) -> str:
         return ""
 
 
-def track_print_call(func):
-    def wrapper(*args, **kwargs):
-        wrapper.has_been_called = True
-        return func(*args, **kwargs)
-
-    wrapper.has_been_called = False  # Initialize as False
-    return wrapper
-
-
-@track_print_call
 def print_error_header():
     """Print error message.
     :returns: Print error head to user


### PR DESCRIPTION
## Problem

`track_print_call` decorator on `print_error_header` used a function attribute (`has_been_called`) as implicit global state. This required manual reset in `main.py` with `_peh.has_been_called = False`, which is fragile and creates a hidden side effect.

## Solution

Move banner-once tracking into `ValidationEngine` and `BaseValidator` proper instance fields:

### Changes

**`commit_check/util.py`**
- Removed `track_print_call` decorator function entirely
- Removed `@track_print_call` from `print_error_header`
- Simplified `_print_failure`: removed `has_been_called` check — banner-once responsibility moved to `BaseValidator`

**`commit_check/engine.py`**
- Added `_banner_printed: bool` to `BaseValidator` — tracks whether the banner has been printed
- `BaseValidator._print_failure` now prints the banner at most once per run, using `_banner_printed`
- Added `banner_printed: bool` to `ValidationEngine` — coordinates banner state across all validators
- `validate_all()` and `validate_all_detailed()` sync `validator._banner_printed` with engine state

**`commit_check/main.py`**
- Removed manual `_peh.has_been_called = False` reset — no longer needed

Closes #3 (internal issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error output so the error banner appears at most once per run, followed by individual failures.
  * Made failure messaging more consistent across all checks in a single validation run.
  * Removed redundant banner-state resets, reducing the chance of repeated or inconsistent error headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->