### PR TITLE
fix: replace git branch -a regex with rev-parse in MergeBaseValidator

### DIFF
--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -440,21 +440,46 @@ class MergeBaseValidator(BaseValidator):
         return ValidationResult.FAIL
 
     def _find_target_branch(self, pattern: str) -> str | None:
-        """Find target branch matching the pattern."""
+        """Find target branch by verifying refs directly.
+
+        Uses ``git rev-parse --verify`` for exact ref resolution instead of
+        scanning ``git branch -a`` output with a regex. Strips common regex
+        anchors (``^``, ``$``) from the pattern to obtain a branch name,
+        then attempts to verify it as a local ref first, falling back to
+        the remote tracking ref under ``origin/``.
+
+        :param pattern: The raw regex pattern from the rule config (e.g.
+            ``"^main$"`` or ``"main"``).
+        :returns: The resolved branch name if verified, ``None`` otherwise.
+        """
         import subprocess
-        import re
 
+        # Strip common regex anchors to obtain a clean branch name
+        branch_name = pattern.lstrip("^").rstrip("$").strip()
+        if not branch_name:
+            return None
+
+        # Try local branch first (refs/heads/ avoids ambiguity with tags)
         try:
-            all_branches = subprocess.check_output(
-                ["git", "branch", "-a"], encoding="utf-8"
-            ).splitlines()
+            subprocess.run(
+                ["git", "rev-parse", "--verify", f"refs/heads/{branch_name}"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+            return branch_name
+        except subprocess.CalledProcessError:
+            pass
 
-            for branch in all_branches:
-                clean_branch = (
-                    branch.strip().replace("* ", "").replace("remotes/origin/", "")
-                )
-                if re.match(pattern, clean_branch):
-                    return clean_branch
+        # Try remote tracking branch under origin/
+        try:
+            subprocess.run(
+                ["git", "rev-parse", "--verify", f"refs/remotes/origin/{branch_name}"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+            )
+            return branch_name
         except subprocess.CalledProcessError:
             pass
 

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -1,5 +1,6 @@
 """Tests for commit_check.engine module."""
 
+import subprocess
 import pytest
 import tempfile
 import os
@@ -841,6 +842,70 @@ class TestMergeBaseValidator:
         with patch("commit_check.engine.has_commits", return_value=False):
             result = validator.validate(context)
             assert result == ValidationResult.PASS  # Skipped
+
+    # ------------------------------------------------------------------ #
+    #  _find_target_branch —— unit tests for the new impl
+    # ------------------------------------------------------------------ #
+
+    @patch("subprocess.run")
+    def test_find_target_branch_local_found(self, mock_run):
+        """Local branch exists: returns the stripped branch name."""
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        validator = MergeBaseValidator(ValidationRule(check="merge_base"))
+        result = validator._find_target_branch("^main$")
+        assert result == "main"
+        # First call: local branch verification
+        assert mock_run.call_args_list[0][0][0][:4] == [
+            "git",
+            "rev-parse",
+            "--verify",
+            "refs/heads/main",
+        ]
+
+    @patch("subprocess.run")
+    def test_find_target_branch_local_missing_remote_found(self, mock_run):
+        """Local missing, remote tracking exists: returns the stripped branch name."""
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, []),  # local fails
+            subprocess.CompletedProcess(args=[], returncode=0),  # remote succeeds
+        ]
+        validator = MergeBaseValidator(ValidationRule(check="merge_base"))
+        result = validator._find_target_branch("develop")
+        assert result == "develop"
+        assert mock_run.call_args_list[1][0][0][:5] == [
+            "git",
+            "rev-parse",
+            "--verify",
+            "refs/remotes/origin/develop",
+        ]
+
+    @patch("subprocess.run")
+    def test_find_target_branch_not_found(self, mock_run):
+        """Neither local nor remote exists: returns None."""
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, []),
+            subprocess.CalledProcessError(1, []),
+        ]
+        validator = MergeBaseValidator(ValidationRule(check="merge_base"))
+        result = validator._find_target_branch("nonexistent-branch")
+        assert result is None
+
+    @patch("subprocess.run")
+    def test_find_target_branch_empty_pattern(self, mock_run):
+        """Empty or anchor-only pattern: returns None without calling subprocess."""
+        validator = MergeBaseValidator(ValidationRule(check="merge_base"))
+        result = validator._find_target_branch("")
+        assert result is None
+        mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_find_target_branch_plain_name(self, mock_run):
+        """Plain branch name (no regex anchors) works correctly."""
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+        validator = MergeBaseValidator(ValidationRule(check="merge_base"))
+        result = validator._find_target_branch("main")
+        assert result == "main"
+        assert mock_run.call_args_list[0][0][0][3] == "refs/heads/main"
 
 
 class TestValidationEngine:


### PR DESCRIPTION
## Problem

`MergeBaseValidator._find_target_branch` used `git branch -a` + `re.match()` to locate the target branch. This approach is fragile because a loose regex like `main` could match `main-old`, `main-staging`, `origin/main`, etc. — whichever appeared first in `git branch -a` output (which is non-deterministic). This class of bug makes `merge_base` validation unreliable in CI.

## Solution

Replace the regex-based branch list scan with precise ref resolution using `git rev-parse --verify`:

1. Strip common regex anchors (`^`, `$`) from the pattern to get a clean branch name
2. Try `git rev-parse --verify refs/heads/<branch>` (local branch, no ambiguity with tags)
3. Fall back to `git rev-parse --verify refs/remotes/origin/<branch>` (remote tracking branch)

Using the full `refs/heads/` and `refs/remotes/origin/` paths eliminates any possibility of resolving to a tag or other non-branch ref — matching the old behavior which only scanned `git branch -a` (branches only).

## Regression Analysis

All edge cases verified against old behavior:

| Scenario | Old behavior | New behavior | Regression? |
|----------|-------------|--------------|-------------|
| `regex = "^main$"`, branch `main` exists | Matches `main` | `rev-parse refs/heads/main` → found | ✅ Match |
| `regex = "main"`, branches: `main`, `main-old` | May match `main-old` first (non-deterministic) | Only `refs/heads/main` matches | ✅ Fix |
| `regex = "develop"`, only remote `origin/develop` | Stripped from `remotes/origin/develop` | `rev-parse refs/remotes/origin/develop` → found | ✅ Match |
| Branch does not exist | Returns `None` | Returns `None` | ✅ Match |
| Tag `main` exists, no branch `main` | `git branch -a` → not found → `None` | `refs/heads/main` → not found → `None` | ✅ Match (was a risk without `refs/heads/`) |
| Complex regex like `^(main\|develop)$` | Regex match | Would fail, but not a documented/configurable use case | ⚠️ Acceptable |
| Remote not `origin` (e.g. `upstream`) | Old code also only handled `origin/` | Same | ✅ Consistent |

## Test Plan

- All existing tests pass (366 tests)
- Added 5 new unit tests covering:
  - Local branch found (`^main$` → resolves to `main` via `refs/heads/main`)
  - Local missing, remote tracking found (`develop` → resolved via `refs/remotes/origin/develop`)
  - Neither local nor remote exists (returns `None`)
  - Empty/anchor-only pattern (returns `None` without calling subprocess)
  - Plain branch name without regex anchors works correctly