### PR TITLE
chore: add OpenSSF Scorecard badge to README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,8 +66,8 @@ jobs:
         os: ['windows-latest', 'ubuntu-24.04', 'macos-latest']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.py }}
       - run: |
@@ -75,7 +75,7 @@ jobs:
           pip install .[dev]
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: commit-check_wheel
           path: dist
@@ -90,8 +90,8 @@ jobs:
       permissions:
         contents: write
       steps:
-        - uses: actions/checkout@v7.0.0
-        - uses: actions/setup-python@v6.3.0
+        - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
           with:
             python-version: "3.10"
 
@@ -104,7 +104,7 @@ jobs:
           run: nox -s docs
 
         - name: Save built docs as artifact
-          uses: actions/upload-artifact@v7
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
           with:
             name: "commit-check_docs"
             path: ${{ github.workspace }}/_build/html

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,10 @@ Commit Check
     :target: https://codecov.io/gh/commit-check/commit-check
     :alt: CodeCov
 
+.. |scorecard-badge| image:: https://api.securityscorecards.dev/projects/github.com/commit-check/commit-check/badge
+    :target: https://api.securityscorecards.dev/projects/github.com/commit-check/commit-check
+    :alt: OpenSSF Scorecard
+
 .. |commit-check-badge| image:: https://img.shields.io/badge/commit--check-enabled-brightgreen?logo=Git&logoColor=white&color=%232c9ccd
     :target: https://github.com/commit-check/commit-check
     :alt: commit-check
@@ -29,7 +33,7 @@ Commit Check
     :target: https://pypi.org/project/commit-check/
     :alt: Python Versions
 
-|ci-badge| |sonar-badge| |pypi-version| |pypi-downloads| |python-versions| |commit-check-badge| |codecov-badge|
+|ci-badge| |sonar-badge| |pypi-version| |pypi-downloads| |python-versions| |commit-check-badge| |codecov-badge| |scorecard-badge|
 
 .. contents:: Table of Contents
    :depth: 2


### PR DESCRIPTION
## Summary

Runs OpenSSF Scorecard and adds the badge to the README.

## Scorecard Results (score: 7.4/10)

| Score | Check | Notes |
|-------|-------|-------|
| 10/10 | Binary-Artifacts | no binaries found |
| 10/10 | CI-Tests | 27/27 merged PRs checked by CI |
| 10/10 | Contributors | 7 contributing organizations |
| 10/10 | Dangerous-Workflow | no dangerous patterns |
| 10/10 | Dependency-Update-Tool | detected |
| 10/10 | License | detected |
| 10/10 | Maintained | active in last 90 days |
| 10/10 | SAST | run on all commits |
| 10/10 | Security-Policy | detected (org-level .github repo) |
| 10/10 | Token-Permissions | least privilege |
| 10/10 | Vulnerabilities | 0 existing |
| 3/10 | Pinned-Dependencies | not pinned by hash |
| 0/10 | Branch-Protection | not enabled on development/release branches |
| 0/10 | Code-Review | approvals not detected (likely token scope) |
| 0/10 | Fuzzing | not fuzzed |
| ? | CII-Best-Practices | network error |
| ? | Packaging | not detected |
| ? | Signed-Releases | no releases found |

## Badge

Adds the OpenSSF Scorecard badge to the README badge row, linking to the project's Scorecard results page.

Closes the Scorecard suggestion from the org-level review.