### PR TITLE
chore: migrate publish to pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -39,15 +39,14 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: github.event_name == 'workflow_dispatch' && github.repository == 'commit-check/commit-check'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-      run: twine upload --repository testpypi dist/commit_check*
+      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        password: ${{ secrets.TEST_PYPI_TOKEN }}
       continue-on-error: true
 
     - name: Publish package to PyPI
       if: github.event_name != 'workflow_dispatch' && github.repository == 'commit-check/commit-check'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: twine upload dist/commit_check*
+      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Scorecard's Packaging check expects PyPI publishing to use the official `pypa/gh-action-pypi-publish` action. This PR migrates from raw `twine upload` commands to the action.

## Changes

- **Publish to TestPyPI** — replaced `twine upload --repository testpypi` with `pypa/gh-action-pypi-publish` using `repository-url: https://test.pypi.org/legacy/`
- **Publish to PyPI** — replaced `twine upload` with `pypa/gh-action-pypi-publish`
- Removed now-unnecessary `TWINE_USERNAME` env vars (the action handles auth via the `password` input)

Action pinned by SHA: `6733eb7d741f0b11ec6a39b58540dab7590f9b7d` (`v1.14.0`).

Part of the Scorecard improvement effort (currently `?` for Packaging → `10/10` after merge).