### PR TITLE
fix: move id-token: write to job-level for Scorecard API compliance

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,12 +6,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
   analysis:
     runs-on: ubuntu-24.04
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Problem

The [OpenSSF Scorecard workflow](https://github.com/commit-check/commit-check/actions/runs/28650112259) is failing with:

> ```
> workflow verification failed: global perm is set to write: permission for id-token is set to write
> ```

The Scorecard Action v2.4.3 [enforces workflow restrictions](https://github.com/ossf/scorecard-action#workflow-restrictions) when `publish_results: true`:

> **No workflow level write permissions** — only the job containing `ossf/scorecard-action` may use `id-token: write`.

The workflow had `id-token: write` at the **top-level** `permissions` block, which the Scorecard API treated as a global write permission and rejected with a 400 Bad Request.

## Fix

Move `id-token: write` from the **top-level** `permissions` to the **job-level** `permissions` under the `analysis` job, keeping only `contents: read` at the top level.

## Verification

- ✅ `git diff` shows only the expected permission scope change
- ✅ Pre-commit hooks passed (yaml lint, codespell, commit message checks)