### PR TITLE
fix(require_signed_off_by): allow any name

### DIFF
--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -100,7 +100,7 @@ COMMIT_RULES = [
     ),
     RuleCatalogEntry(
         check="require_signed_off_by",
-        regex=r"Signed-off-by:.*[A-Za-z0-9]\s+<.+@.+>",
+        regex=r"Signed-off-by: .+ <.+@.+>",
         error="Signed-off-by not found in latest commit",
         suggest="git commit --amend --signoff or use --signoff on commit",
     ),


### PR DESCRIPTION
This regex is too strict right now. Same could probably be said about the author_name regex. It catches bots like dependabot incorrectly.

---

Dependabot uses the following sign off trailer:
```
Signed-off-by: dependabot[bot] <support@github.com>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened commit sign-off validation so only properly formatted `Signed-off-by` entries are accepted.
  * Improved consistency in commit checks by reducing false positives from loosely formatted sign-off lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->