### PR TITLE
fix: skip signoff check for ignored authors

### DIFF
--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -493,7 +493,7 @@ class SignoffValidator(BaseValidator):
     """Validates that commit messages contain required signoff trailer."""
 
     def validate(self, context: ValidationContext) -> ValidationResult:
-        if self._should_skip_validation(context):
+        if self._should_skip_commit_validation(context):
             return ValidationResult.PASS
 
         message = self._get_commit_message(context)

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -708,6 +708,23 @@ class TestSignoffValidator:
             result = validator.validate(context)
         assert result == ValidationResult.FAIL
 
+    @patch("commit_check.engine.get_commit_info")
+    @pytest.mark.benchmark
+    def test_default_signoff_skips_ignored_author(self, mock_get_commit_info):
+        """Signoff check is skipped when the author is in ignore_authors.
+
+        A commit with no signoff would normally fail, but an ignored author
+        (e.g. a bot) should bypass the signoff check just like every other
+        commit check.
+        """
+        mock_get_commit_info.return_value = "dependabot[bot]"
+        validator = SignoffValidator(self._default_signoff_rule())
+        config = {"commit": {"ignore_authors": ["dependabot[bot]"]}}
+        context = ValidationContext(stdin_text="chore: bump dep", config=config)
+
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS
+
     @pytest.mark.benchmark
     def test_signoff_validator_missing_signoff(self):
         """Test SignoffValidator with missing signoff."""


### PR DESCRIPTION
SignoffValidator used the base skip helper, so it was the only commit-level check that did not honor ignore_authors — a bot in the ignore list still had its signoff validated. Use _should_skip_commit_validation so signoff is skipped for ignored authors, consistent with the message, author, and body checks. Add a test covering the skip behavior.