### PR TITLE
chore: remove redundant --message flag from check-message pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,6 @@
   name: check commit message
   description: ensures commit message to match regex
   entry: commit-check
-  args: [--message]
   stages: [commit-msg]
   pass_filenames: true
   language: python

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -351,41 +351,6 @@ def _get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _get_message_content(
-    message_arg: str | None, stdin_reader: StdinReader
-) -> str | None:
-    """Get commit message content from argument, file, or stdin."""
-    if message_arg is None:
-        return None
-
-    # If message_arg is empty string (from nargs="?", const=""), try stdin first, then git
-    if message_arg == "":
-        # Try reading from stdin if available
-        stdin_content = stdin_reader.read_piped_input()
-        if stdin_content:
-            return stdin_content
-
-        # Fallback to latest git commit message
-        try:
-            from commit_check.util import get_commit_info
-
-            return get_commit_info("B")  # Full commit message
-        except Exception:
-            print(
-                "Error: No commit message provided and unable to read from git",
-                file=sys.stderr,
-            )
-            return None
-
-    # If message_arg is a file path, read from file
-    try:
-        with open(message_arg, "r", encoding="utf-8") as f:
-            return f.read().strip()
-    except (OSError, IOError) as e:
-        print(f"Error reading message file '{message_arg}': {e}", file=sys.stderr)
-        return None
-
-
 def _resolve_commit_message_source(
     args: argparse.Namespace,
     stdin_reader: StdinReader,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,7 +7,6 @@ import os
 from commit_check.main import (
     StdinReader,
     _build_pre_commit_push_input,
-    _get_message_content,
     main,
 )
 
@@ -148,69 +147,6 @@ class TestStdinReader:
         mocker.patch("sys.stdin.read", side_effect=IOError("Input error"))
         result = reader.read_piped_input()
         assert result is None
-
-
-class TestGetMessageContent:
-    """Test _get_message_content function edge cases."""
-
-    @pytest.mark.benchmark
-    def test_get_message_content_empty_string_with_stdin(self, mocker):
-        """Test _get_message_content with empty string and stdin available."""
-        reader = StdinReader()
-
-        mocker.patch.object(reader, "read_piped_input", return_value="piped message")
-        result = _get_message_content("", reader)
-        assert result == "piped message"
-
-    @pytest.mark.benchmark
-    def test_get_message_content_empty_string_no_stdin_with_git(self, mocker):
-        """Test _get_message_content with empty string, no stdin, fallback to git."""
-        reader = StdinReader()
-
-        mocker.patch.object(reader, "read_piped_input", return_value=None)
-        mocker.patch(
-            "commit_check.util.get_commit_info", return_value="git commit message"
-        )
-        result = _get_message_content("", reader)
-        assert result == "git commit message"
-
-    @pytest.mark.benchmark
-    def test_get_message_content_empty_string_no_stdin_git_fails(self, capsys, mocker):
-        """Test _get_message_content with empty string, no stdin, git fails."""
-        reader = StdinReader()
-
-        mocker.patch.object(reader, "read_piped_input", return_value=None)
-        mocker.patch(
-            "commit_check.util.get_commit_info", side_effect=Exception("Git error")
-        )
-        result = _get_message_content("", reader)
-        assert result is None
-
-        captured = capsys.readouterr()
-        assert "Error: No commit message provided" in captured.err
-
-    @pytest.mark.benchmark
-    def test_get_message_content_file_read_error(self, capsys):
-        """Test _get_message_content with file read error."""
-        reader = StdinReader()
-
-        result = _get_message_content("/nonexistent/file.txt", reader)
-        assert result is None
-
-        captured = capsys.readouterr()
-        assert "Error reading message file" in captured.err
-
-    @pytest.mark.benchmark
-    def test_get_message_content_file_permission_error(self, capsys, mocker):
-        """Test _get_message_content with file permission error."""
-        reader = StdinReader()
-
-        mocker.patch("builtins.open", side_effect=PermissionError("Permission denied"))
-        result = _get_message_content("protected_file.txt", reader)
-        assert result is None
-
-        captured = capsys.readouterr()
-        assert "Error reading message file" in captured.err
 
 
 class TestMainFunctionEdgeCases:


### PR DESCRIPTION
## Summary

AI review pointed out that the `check-message` pre-commit hook's use of `args: [--message]` combined with `pass_filenames: true` is unintuitive — pre-commit runs `commit-check --message COMMIT_EDITMSG_PATH`, where `--message` is a store_true flag but looks like it takes the message content as a value.

## Changes

1. **`.pre-commit-hooks.yaml`**: Removed `args: [--message]` from `check-message`. The hook now runs as `commit-check COMMIT_EDITMSG_PATH`, relying on the positional argument auto-detection (already handled at main.py:484-486).

2. **`commit_check/main.py`**: Removed dead code `_get_message_content()` — it was defined but never called in production.

3. **`tests/main_test.py`**: Removed corresponding import and `TestGetMessageContent` test class.

## Verification

- All 411 existing tests pass
- Pre-commit hooks passed on commit (including commit-check itself)