### PR TITLE
docs: add Discussions link to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -616,7 +616,7 @@ Versioning follows `Semantic Versioning <https://semver.org/>`_.
 Have question or feedback?
 --------------------------
 
-Please post to `issues <https://github.com/commit-check/commit-check/issues>`_ for feedback, feature requests, or bug reports.
+Please post to `issues <https://github.com/commit-check/commit-check/issues>`_ or start a `discussion <https://github.com/commit-check/commit-check/discussions>`_ for feedback, feature requests, or bug reports.
 
 License
 -------


### PR DESCRIPTION
The project already has Discussions enabled at https://github.com/commit-check/commit-check/discussions, but the README only directs users to Issues. This adds the Discussions link alongside Issues so the community knows where to ask questions and share ideas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to direct users to both GitHub Issues and GitHub Discussions for feedback, feature requests, and bug reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->