### PR TITLE
fix: resolve SonarCloud code scanning alerts for pip install security

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Install nox
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install nox
+          python -m pip install --only-binary :all: --upgrade pip
+          python -m pip install --only-binary :all: ".[dev]"
 
       - name: Run pre-commit
         run: |
@@ -71,8 +71,8 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
       - run: |
-          pip install --upgrade pip
-          pip install .[dev]
+          pip install --only-binary :all: --upgrade pip
+          pip install --only-binary :all: .[dev]
 
       - name: Download wheel artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -97,8 +97,8 @@ jobs:
 
         - name: Install nox
           run: |
-            python -m pip install --upgrade pip
-            python -m pip install nox
+            python -m pip install --only-binary :all: --upgrade pip
+            python -m pip install --only-binary :all: ".[dev]"
 
         - name: Build docs
           run: nox -s docs

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,7 +26,8 @@ jobs:
     - name: Build wheel
       run: |
         # Install dependencies
-        python -m pip install --upgrade pip twine
+        python -m pip install --only-binary :all: --upgrade pip
+        python -m pip install --only-binary :all: ".[ci]"
         # Build wheel
         python -m pip wheel -w dist .
         # Check distribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,10 @@ tracker = "https://github.com/commit-check/commit-check/issues"
 #     https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
 
 [project.optional-dependencies]
-dev = ['nox']
+dev = ['nox==2026.7.11']
 test = ['coverage', 'pytest', 'pytest-mock', 'pytest-codspeed']
 docs = ['sphinx<9', 'sphinx-immaterial', 'sphinx-autobuild', 'sphinx_issues', 'myst-parser']
+ci = ['twine==6.2.0']
 
 [tool.setuptools]
 zip-safe = false


### PR DESCRIPTION
## Summary

Fix all 8 open SonarCloud code scanning alerts (S8541 + S8544) by securing `pip install` commands in CI workflows.

## Changes

### `pyproject.toml`
- Pin `nox` to exact version `2026.7.11` in `dev` optional deps
- Add new `ci` optional deps group with pinned `twine==6.2.0`

### `.github/workflows/main.yml`
- Add `--only-binary :all:` to all `pip install` commands (fixes S8541)
- Change standalone `pip install nox` to `pip install .[dev]` (versions managed by pyproject.toml)

### `.github/workflows/publish-package.yml`
- Split `pip install --upgrade pip twine` into two steps
- Install twine via `.[ci]` extras (fixes S8544)

## Alerts fixed

| # | File | Rule | Description |
|---|------|------|-------------|
| 53 | main.yml | S8544 | Locked versions via `.[dev]` |
| 54 | main.yml | S8544 | Locked versions via `.[dev]` |
| 55 | main.yml | S8541 | Added `--only-binary :all:` |
| 56 | main.yml | S8544 | Locked versions via `.[dev]` |
| 58 | main.yml | S8544 | Locked versions via `.[dev]` |
| 59 | main.yml | S8544 | Locked versions via `.[dev]` |
| 60 | main.yml | S8544 | Locked versions via `.[dev]` |
| 63 | publish-package.yml | S8544 | Locked versions via `.[ci]` |

## Why this approach

Version pins are centralized in `pyproject.toml` instead of hardcoded in workflow YAML. Dependabot (already configured for pip ecosystem) will automatically open PRs to update `nox` and `twine` versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build, testing, documentation, and package publishing workflows by consistently using pre-built dependency packages.
  - Standardized development environment setup across automated checks and documentation builds.
  - Pinned the development automation tool to a specific version for more predictable results.
  - Updated package-building checks to use the same reliable dependency installation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->