### PR TITLE
test: mock git config in signoff ignore-author test

### DIFF
--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -821,9 +821,12 @@ class TestSignoffValidator:
             result = validator.validate(context)
         assert result == ValidationResult.FAIL
 
+    @patch(GIT_CONFIG_VALUE)
     @patch("commit_check.engine.get_commit_info")
     @pytest.mark.benchmark
-    def test_default_signoff_skips_ignored_author(self, mock_get_commit_info):
+    def test_default_signoff_skips_ignored_author(
+        self, mock_get_commit_info, mock_get_git_config_value
+    ):
         """Signoff check is skipped when the author is in ignore_authors.
 
         A commit with no signoff would normally fail, but an ignored author
@@ -831,6 +834,9 @@ class TestSignoffValidator:
         commit check.
         """
         mock_get_commit_info.return_value = "dependabot[bot]"
+        # Mock git config so author resolution falls back to the commit author
+        # instead of the developer's real local user.name.
+        mock_get_git_config_value.return_value = ""
         validator = SignoffValidator(self._default_signoff_rule())
         config = {"commit": {"ignore_authors": ["dependabot[bot]"]}}
         context = ValidationContext(stdin_text="chore: bump dep", config=config)


### PR DESCRIPTION
## Summary

`test_default_signoff_skips_ignored_author` did not mock `get_git_config_value`, which makes it environment-dependent and fail on any machine where the developer has a local `git config user.name` set.

## Root cause

Author resolution (`_resolve_current_author`) reads `git config user.name` first when validating a prospective message (stdin). The test only mocked `get_commit_info` (returning the ignored bot author), so with a real `user.name` configured, resolution returned the developer's name instead of `dependabot[bot]` — the author was not recognized as ignored, the signoff check ran, and the test failed. It only passed in environments where `user.name` happened to be unset (e.g. CI).

## Fix

Mock `get_git_config_value` to return an empty string so author resolution deterministically falls back to the commit author (`get_commit_info("an")`), matching the test's intent. No production code changes.

## Verification

- The test now passes regardless of the local `user.name` setting.
- Full test suite passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EP4xvwiuE98BeYSpe7EbyB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to ensure default sign-off behavior correctly falls back to the commit author when local Git author configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->