### PR TITLE
fix: handle PackageNotFoundError when commit-check is not installed

### DIFF
--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -6,7 +6,7 @@ Exports:
         __version__ (package version)
 """
 
-from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 
 # Exit codes used across the package
 PASS = 0
@@ -76,4 +76,7 @@ DEFAULT_BOOLEAN_RULES = {
 DEFAULT_AI_ATTRIBUTION = "ignore"  # "ignore" | "forbid"
 
 
-__version__ = version("commit-check")
+try:
+    __version__ = version("commit-check")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev"

--- a/tests/version_test.py
+++ b/tests/version_test.py
@@ -1,0 +1,28 @@
+"""Tests for commit_check.__version__."""
+
+import importlib
+import pytest
+from unittest.mock import patch
+from importlib.metadata import PackageNotFoundError
+import commit_check
+
+
+class TestVersion:
+    """Tests for __version__ resolution."""
+
+    @pytest.mark.benchmark
+    def test_version_is_string_when_installed(self):
+        """When the package is installed, __version__ must be a non-empty string."""
+        assert isinstance(commit_check.__version__, str)
+        assert len(commit_check.__version__) > 0
+
+    @pytest.mark.benchmark
+    def test_version_fallback_when_not_installed(self):
+        """When PackageNotFoundError is raised, __version__ must fall back to '0.0.0.dev'."""
+        with patch("importlib.metadata.version", side_effect=PackageNotFoundError):
+            importlib.reload(commit_check)
+            assert commit_check.__version__ == "0.0.0.dev"
+
+        # Reload again to restore original version
+        importlib.reload(commit_check)
+        assert isinstance(commit_check.__version__, str)


### PR DESCRIPTION
## Summary

When importing `commit_check` in a development environment where the package hasn't been `pip install`-ed (e.g., running directly with `uv` or `python -m`), `importlib.metadata.version("commit-check")` raises `PackageNotFoundError`, causing the entire import to crash.

## Changes

- Import `PackageNotFoundError` alongside `version` from `importlib.metadata`
- Wrap `__version__` assignment in a `try/except PackageNotFoundError`
- Fall back to `"0.0.0.dev"` when the package is not installed

## Tests

Added `tests/version_test.py` with two test cases:

1. **test_version_is_string_when_installed** — verifies `__version__` is a non-empty string under normal conditions
2. **test_version_fallback_when_not_installed** — mocks `importlib.metadata.version` to raise `PackageNotFoundError`, then reloads the module and asserts `__version__ == "0.0.0.dev"`

## Verification

- `import commit_check` no longer crashes in an uninstalled (development) environment
- `__version__` resolves correctly when the package is installed
- All existing tests and the two new tests pass