### PR TITLE
chore: remove dead code _find_check

### DIFF
--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -12,14 +12,6 @@ from subprocess import CalledProcessError
 from commit_check import RED, GREEN, YELLOW, RESET_COLOR
 
 
-def _find_check(checks: list, check_type: str) -> dict | None:
-    """Return the first check dict matching check_type, else None."""
-    for check in checks:
-        if check.get("check") == check_type:
-            return check
-    return None
-
-
 def _print_failure(
     check: dict,
     actual: str,

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -15,7 +15,6 @@ from commit_check.util import (
     print_error_header,
     print_error_message,
     print_suggestion,
-    _find_check,
 )
 from subprocess import CalledProcessError, PIPE
 from unittest.mock import MagicMock
@@ -614,32 +613,6 @@ class TestUtil:
             assert e.value.code == 1
             stdout, _ = capfd.readouterr()
             assert "commit-check does not support" in stdout
-
-    class TestHelperFunctions:
-        """Tests for utility helper functions to improve coverage."""
-
-        def test_find_check_found(self):
-            """Test _find_check when check is found."""
-            checks = [
-                {"check": "commit-message", "regex": ".*"},
-                {"check": "branch-name", "regex": ".*"},
-            ]
-            result = _find_check(checks, "commit-message")
-            assert result == {"check": "commit-message", "regex": ".*"}
-
-        def test_find_check_not_found(self):
-            """Test _find_check when check is not found."""
-            checks = [
-                {"check": "commit-message", "regex": ".*"},
-            ]
-            result = _find_check(checks, "author-name")
-            assert result is None
-
-        def test_find_check_empty_list(self):
-            """Test _find_check with empty list."""
-            checks = []
-            result = _find_check(checks, "commit-message")
-            assert result is None
 
 
 class TestGetGitConfigValue:


### PR DESCRIPTION
## Summary

`_find_check` in `commit_check/util.py` is no longer referenced by any production code. Only its tests in `tests/util_test.py` still called it — this is dead code.

## Changes

- **`commit_check/util.py`**: Removed the `_find_check` function definition (11 lines)
- **`tests/util_test.py`**: Removed the `_find_check` import and the entire `TestHelperFunctions` test class (3 test methods)

## Verification

- `grep -rn "_find_check"` confirms zero references outside of the deleted lines
- `ruff check` / `ruff format` / `mypy` all pass
- All 434 tests pass (`python3 -m pytest -x -q`)