### PR TITLE
chore: remove dead else branch in print_suggestion()

### DIFF
--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -301,7 +301,7 @@ def print_error_message(check_type: str, error: str, reason: str):
         print(error)
 
 
-def print_suggestion(suggest: str | None) -> None:
+def print_suggestion(suggest: str) -> None:
     """Print suggestion to user
     :param suggest: what message to print out
     """
@@ -310,7 +310,4 @@ def print_suggestion(suggest: str | None) -> None:
             f"Suggest: {GREEN}{suggest}{RESET_COLOR} ",
             end="",
         )
-    else:
-        print(f"commit-check does not support {suggest} yet.")
-        raise SystemExit(1)
     print("\n")

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -27,7 +27,7 @@ def _print_failure(
         print_error_header()
     print_error_message(check["check"], check.get("error", ""), actual)
     if check.get("suggest"):
-        print_suggestion(check.get("suggest"))
+        print_suggestion(check["suggest"])
 
 
 def get_branch_name() -> str:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -605,15 +605,6 @@ class TestUtil:
             stdout, _ = capfd.readouterr()
             assert "Suggest:" in stdout
 
-        @pytest.mark.benchmark
-        def test_print_suggestion_exit1(self, capfd):
-            # Must exit with 1 when "" passed
-            with pytest.raises(SystemExit) as e:
-                print_suggestion("")
-            assert e.value.code == 1
-            stdout, _ = capfd.readouterr()
-            assert "commit-check does not support" in stdout
-
 
 class TestGetGitConfigValue:
     """Tests for get_git_config_value utility function."""


### PR DESCRIPTION
修复issue486的问题，删掉了已经判断过而不可能进入的print_suggestion函数中的else分支，测试脚本已一并改动

(Machine translation / 机器翻译)
Removed the unreachable else branch in print_suggestion() that could never
be entered since all callers already guard with a truthy check. Updated the
type hint from str | None to str, and removed the corresponding test.

Close #486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Git configuration values, including correct behavior for missing settings and command errors.
  * Commit suggestions now print cleanly when available, without exiting when suggestions are unsupported or empty.
* **Tests**
  * Added new test coverage for retrieving Git user name and email across success, not-set, and error cases.
  * Removed the prior test asserting program termination when no suggestion is supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->