### PR TITLE
chore: use pull_request_target for auto-labeler on fork PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,8 +1,8 @@
 name: PR Auto-labeler
 
 on:
-  # pull_request event is required for auto-labeler
-  pull_request:
+  # pull_request_target event is required for auto-labeler on fork PRs
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions: {}


### PR DESCRIPTION
## Summary

When a PR is opened from a **fork** repository (e.g. #487 by @XEDAB), the `pull_request` event's `GITHUB_TOKEN` has **read-only** permissions, causing the autolabeler to fail with:

```
Resource not accessible by integration
```

Changing to `pull_request_target` runs the workflow in the context of the base repository, giving the token write permissions needed to add labels.

## Why this is safe

The autolabeler (`release-drafter/release-drafter/autolabeler`) only:
- Reads PR metadata (title, branch name, changed files)
- Matches against the release-drafter config
- Adds labels to the PR

It does **not** checkout any code from the fork, so there is no security risk from using `pull_request_target`.

## Related

- Fixes autolabeler failure on #487
- See failing run: https://github.com/commit-check/commit-check/actions/runs/30514001590/job/90926505631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request auto-labeling workflow trigger.
  * Existing labeling behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->