### PR TITLE
test: add cases for BodyValidator leading blank line edge cases

### DIFF
--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -967,6 +967,50 @@ class TestBodyValidator:
         with patch("commit_check.util._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
+    
+    @pytest.mark.benchmark
+    def test_validate_with_leading_blank_lines_and_body(self):
+        """Test body validation with leading blank lines before body content.
+
+        _get_commit_message() strips input before BodyValidator sees it, so
+        leading blank lines are removed and this collapses to a single line
+        with no separate subject/body it should FAIL.
+        """
+        rule = ValidationRule(check="require_body")
+        validator = BodyValidator(rule)
+        context = ValidationContext(stdin_text="\n\nbody content")
+
+        with patch("commit_check.util._print_failure"):
+            result = validator.validate(context)
+            assert result == ValidationResult.FAIL
+
+    @pytest.mark.benchmark
+    def test_validate_with_leading_blank_lines_no_body(self):
+        """Test body validation with only leading blank lines and no content.
+
+        After stripping, this becomes an empty message, which is treated as
+        having no commit message at all — it should PASS.
+        """
+        rule = ValidationRule(check="require_body")
+        validator = BodyValidator(rule)
+        context = ValidationContext(stdin_text="\n\n")
+
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    def test_validate_with_whitespace_only_message(self):
+        """Test body validation with a whitespace-only message.
+
+        After stripping, this becomes an empty message, same as the
+        leading-blank-lines-only case — it should PASS.
+        """
+        rule = ValidationRule(check="require_body")
+        validator = BodyValidator(rule)
+        context = ValidationContext(stdin_text=" \n ")
+
+        result = validator.validate(context)
+        assert result == ValidationResult.PASS
 
 
 class TestMergeBaseValidator:

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -967,7 +967,7 @@ class TestBodyValidator:
         with patch("commit_check.util._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
-    
+
     @pytest.mark.benchmark
     def test_validate_with_leading_blank_lines_and_body(self):
         """Test body validation with leading blank lines before body content.


### PR DESCRIPTION
Closes #490

Added 3 test cases to TestBodyValidator covering leading-blank-line and
whitespace-only commit messages, matching the corrected expected results
in the updated issue description.

Note: lines 556-558 in BodyValidator.validate() still show as uncovered.
I believe this branch is unreachable in practice, since _get_commit_message()
strips the message before validate() runs, a message can never have
content on the first line followed by surviving blank lines by the time
it reaches this check. Happy to look into removing that dead code in a
follow up if useful, just flagging it here for visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for handling leading blank lines and whitespace-only messages.
  * Verified that empty or whitespace-only input is accepted, while improperly formatted body content is rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->