### PR TITLE
Allow docs/, ci/, test/, refactor/ branches by defaultfeat: allow docs, ci, test, refactor branches by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,22 @@ ai_attribution = "forbid"
 [branch]
 # https://conventionalbranch.org
 conventional_branch = true
-allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
-```
+allow_branch_types = [
+    "feature",
+    "bugfix",
+    "hotfix",
+    "release",
+    "chore",
+    "feat",
+    "fix",
+    "build",
+    "ci",
+    "docs",
+    "perf",
+    "refactor",
+    "style",
+    "test",
+]```
 
 > [!TIP]
 > **IDE Autocompletion**

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -41,6 +41,13 @@ DEFAULT_BRANCH_TYPES = [
     "chore",
     "feat",
     "fix",
+    "build",
+    "ci",
+    "docs",
+    "perf",
+    "refactor",
+    "test",
+    "style",
     # AI agent prefixes (conventional branch spec v1.1.0)
     "ai",
     "claude",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -135,7 +135,7 @@ Example Configuration
     [branch]
     # https://conventionalbranch.org
     conventional_branch = true
-    allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+    allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "build", "ci", "docs", "perf", "refactor", "test", "style"]
     # allow_branch_names = []  # Optional - additional standalone branch names (e.g., ["develop", "staging"])
     # require_rebase_target = "main"  # Optional - no rebase requirement by default
     # ignore_authors = []      # Optional - no authors ignored by default
@@ -433,7 +433,7 @@ Options Table Description
    * - branch
      - allow_branch_types
      - list[str]
-     - ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix"]
+     - ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "build", "ci", "docs", "perf", "refactor", "test", "style"]
      - Allowed branch types when conventional_branch is true. AI agent prefixes (``ai/``, ``claude/``, ``codex/``, ``copilot/``, ``cursor/``) and bot prefixes (``dependabot/``) are also included by default.
    * - branch
      - allow_branch_names

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -228,6 +228,13 @@ class TestRuleBuilder:
         assert "cursor" in DEFAULT_BRANCH_TYPES
         assert "dependabot" in DEFAULT_BRANCH_TYPES
         assert "renovate" in DEFAULT_BRANCH_TYPES
+        assert "build" in DEFAULT_BRANCH_TYPES
+        assert "ci" in DEFAULT_BRANCH_TYPES
+        assert "docs" in DEFAULT_BRANCH_TYPES
+        assert "perf" in DEFAULT_BRANCH_TYPES
+        assert "refactor" in DEFAULT_BRANCH_TYPES
+        assert "style" in DEFAULT_BRANCH_TYPES
+        assert "test" in DEFAULT_BRANCH_TYPES
 
         config = {"branch": {"conventional_branch": True}}
         builder = RuleBuilder(config)
@@ -236,6 +243,14 @@ class TestRuleBuilder:
         assert rule is not None
 
         valid_branches = [
+            # Conventional branch types matching default commit types
+            "build/update-ci-image",
+            "ci/github-actions",
+            "docs/update-readme",
+            "perf/optimize-parser",
+            "refactor/simplify-engine",
+            "style/format-code",
+            "test/add-api-tests",
             # AI agent branches
             "ai/refactor-auth-flow",
             "claude/stoic-hypatia-v65p1f",


### PR DESCRIPTION
## Summary

This PR updates the default branch types so they are consistent with the default Conventional Commit types.

### Changes
- Added `build`
- Added `ci`
- Added `docs`
- Added `perf`
- Added `refactor`
- Added `test`
- Added `style`

### Documentation
- Updated README examples
- Updated configuration documentation

### Tests
- Updated the default branch type test to cover the newly added branch prefixes.

This change is purely additive and does not affect existing valid branch names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the default allowed branch types to include `build`, `ci`, `docs`, `perf`, `refactor`, `style`, and `test`.
  * Updated example configurations to reflect the additional branch types.

* **Documentation**
  * Refreshed configuration guidance and examples with the expanded defaults.

* **Tests**
  * Added validation coverage for the newly supported branch types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->