### PR TITLE
fix: detect space-separated AI model names in co-author trailers

### DIFF
--- a/commit_check/ai_signatures_data.py
+++ b/commit_check/ai_signatures_data.py
@@ -89,6 +89,14 @@ CLAUDE_CODE = KnownAiTool(
             r"|\d+\+Claude@users\.noreply\.github\.com)>)?",
             "``Co-authored-by: Claude`` trailer",
         ),
+        # Any co-author name with the Anthropic noreply email — catches
+        # model-name variants such as "Claude Opus 4.5 (1M context)" that
+        # the pattern above misses.
+        _trailer(
+            "Co-authored-by",
+            r"[^<\n]*<noreply@anthropic\.com>",
+            "``Co-authored-by`` with Anthropic noreply email",
+        ),
         # Assisted-by trailer (Linux kernel style, with optional tool list)
         _trailer(
             "Assisted-by",
@@ -222,6 +230,16 @@ GENERIC_AI = KnownAiTool(
             "Co-authored-by",
             r"(?:claude|gpt|gemini)[\w.]*-[\w.-]+(?:\s*<[^>]*>)?",
             "``Co-authored-by`` with AI model name",
+        ),
+        # Catch space-separated AI model identifiers in Co-authored-by
+        # (e.g. "Claude Opus 4.5", "Gemini 2.5 Pro", "GPT 4 Turbo").
+        # A purely numeric version token is required so human names with
+        # ordinals ("Claude Dubois 3rd") are NOT flagged.
+        _trailer(
+            "Co-authored-by",
+            r"(?:claude|gpt|gemini)(?:\s+[a-z]+)*\s+\d+(?:\.\d+)*(?!\w)"
+            r"(?:\s+[a-z]+)*(?:\s*\([^)]*\))?(?:\s*<[^>]*>)?",
+            "``Co-authored-by`` with space-separated AI model name",
         ),
         # Catch Assisted-by trailer (Linux kernel style) regardless of agent,
         # with optional trailing tool list.

--- a/tests/ai_signatures_test.py
+++ b/tests/ai_signatures_test.py
@@ -72,8 +72,7 @@ class TestDetectAiSignatures:
     def test_human_name_with_ordinal_ignored(self):
         """A human name with an ordinal suffix is NOT detected."""
         message = (
-            "feat: add feature\n\n"
-            "Co-authored-by: Claude Dubois 3rd <claude@gmail.com>"
+            "feat: add feature\n\nCo-authored-by: Claude Dubois 3rd <claude@gmail.com>"
         )
         assert not has_ai_signature(message)
 

--- a/tests/ai_signatures_test.py
+++ b/tests/ai_signatures_test.py
@@ -48,6 +48,36 @@ class TestDetectAiSignatures:
         assert len(claude_hits) == 0
 
     @pytest.mark.benchmark
+    def test_claude_model_name_with_noreply_email(self):
+        """Model-name co-author with anthropic noreply is detected."""
+        message = (
+            "feat: add feature\n\n"
+            "Co-authored-by: Claude Opus 4.5 (1M context) <noreply@anthropic.com>"
+        )
+        result = detect_ai_signatures(message)
+        assert any(s["tool"] == "Claude Code" for s in result)
+
+    @pytest.mark.benchmark
+    def test_space_separated_model_name_detected(self):
+        """Space-separated model names with a version are detected."""
+        for trailer in (
+            "Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>",
+            "Co-authored-by: Gemini 2.5 Pro <gemini@example.com>",
+            "Co-authored-by: GPT 4 Turbo",
+        ):
+            message = f"feat: add feature\n\n{trailer}"
+            assert has_ai_signature(message), trailer
+
+    @pytest.mark.benchmark
+    def test_human_name_with_ordinal_ignored(self):
+        """A human name with an ordinal suffix is NOT detected."""
+        message = (
+            "feat: add feature\n\n"
+            "Co-authored-by: Claude Dubois 3rd <claude@gmail.com>"
+        )
+        assert not has_ai_signature(message)
+
+    @pytest.mark.benchmark
     def test_copilot_with_noreply_email(self):
         """Co-authored-by: Copilot with GitHub noreply is detected."""
         message = (


### PR DESCRIPTION
With `ai_attribution = "forbid"`, trailers using space-separated model names pass undetected:

```
Co-Authored-By: Claude Opus 4.5 (1M context) <noreply@anthropic.com>
Co-Authored-By: Gemini 2.5 Pro <gemini@example.com>
```

The Claude pattern only matches `Claude`/`Claude Code` verbatim, and the generic pattern requires hyphenated ids (`claude-sonnet-4`). Claude Code emits such trailers in the wild (observed in our org).

Two new patterns:

- any co-author with the `noreply@anthropic.com` email, regardless of display name;
- space-separated model names with a purely numeric version token, so human names — including ordinals like `Claude Dubois 3rd` — stay unflagged.

Tests added for both, plus the ordinal false-positive case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of AI-generated commit signatures attributed to Claude, including Anthropic email trailers and model-name variants.
  - Added support for identifying space-separated model names with numeric versions, such as Claude Opus 4.5 and GPT 4 Turbo.
  - Reduced false positives by distinguishing AI model signatures from human names containing ordinal suffixes.
- **Tests**
  - Added coverage for the expanded detection scenarios and human-name exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->