### PR TITLE
chore: update pre-commit version reference to v2.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ commit-check --message --branch
 ```yaml
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.11.1
+    rev: v2.12.2
     hooks:
       - id: check-message
       - id: check-branch
@@ -177,7 +177,7 @@ commit-check --message
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.11.1
+    rev: v2.12.2
     hooks:
       - id: check-message
         args:
@@ -207,7 +207,7 @@ commit-check --no-force-push
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.11.1
+    rev: v2.12.2
     hooks:
       - id: check-no-force-push
         stages: [pre-push]


### PR DESCRIPTION
Update the pre-commit hook `rev` examples in README.md from `v2.11.1` to the latest release `v2.12.2` (published 2026-07-31).

Three occurrences updated (Quick Start, environment-variable config, and pre-push hook examples).