### PR TITLE
docs: clarify allow_branch_types defaults are a superset of the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ ai_attribution = "forbid"
 [branch]
 # https://conventionalbranch.org
 conventional_branch = true
+# Optional: the defaults are a superset of the Conventional Branch spec — spec
+# types plus Conventional Commit types (build, ci, docs, perf, refactor, style,
+# test) and AI/bot prefixes (ai, claude, codex, copilot, cursor, dependabot,
+# renovate), see docs/configuration.rst. Omit this option to use the defaults.
 allow_branch_types = [
     "feature",
     "bugfix",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -135,7 +135,26 @@ Example Configuration
     [branch]
     # https://conventionalbranch.org
     conventional_branch = true
-    allow_branch_types = ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "build", "ci", "docs", "perf", "refactor", "test", "style"]
+    # Optional: defaults are a superset of the Conventional Branch spec — the
+    # spec types plus Conventional Commit types, AI agent prefixes and bot
+    # prefixes (see the Options table below for the full list). Omit this
+    # option to use the defaults, or set your own list for a strict subset.
+    allow_branch_types = [
+        "feature",
+        "bugfix",
+        "hotfix",
+        "release",
+        "chore",
+        "feat",
+        "fix",
+        "build",
+        "ci",
+        "docs",
+        "perf",
+        "refactor",
+        "style",
+        "test",
+    ]
     # allow_branch_names = []  # Optional - additional standalone branch names (e.g., ["develop", "staging"])
     # require_rebase_target = "main"  # Optional - no rebase requirement by default
     # ignore_authors = []      # Optional - no authors ignored by default
@@ -433,8 +452,8 @@ Options Table Description
    * - branch
      - allow_branch_types
      - list[str]
-     - ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "build", "ci", "docs", "perf", "refactor", "test", "style"]
-     - Allowed branch types when conventional_branch is true. AI agent prefixes (``ai/``, ``claude/``, ``codex/``, ``copilot/``, ``cursor/``) and bot prefixes (``dependabot/``) are also included by default.
+     - ["feature", "bugfix", "hotfix", "release", "chore", "feat", "fix", "build", "ci", "docs", "perf", "refactor", "style", "test", "ai", "claude", "codex", "copilot", "cursor", "dependabot", "renovate"]
+     - Allowed branch types when ``conventional_branch`` is true. The default is a superset of the `Conventional Branch spec <https://conventionalbranch.org/>`_: the spec types (``feature``, ``bugfix``, ``hotfix``, ``release``, ``chore``) plus the Conventional Commit types (``build``, ``ci``, ``docs``, ``perf``, ``refactor``, ``style``, ``test``), AI agent prefixes (``ai``, ``claude``, ``codex``, ``copilot``, ``cursor``) and bot prefixes (``dependabot``, ``renovate``). For strict spec-only validation, set this option explicitly (e.g. ``["feature", "bugfix", "hotfix", "release", "chore"]``).
    * - branch
      - allow_branch_names
      - list[str]


### PR DESCRIPTION
## Summary

Follow-up to #505 (merged). Two documentation cleanups requested during review:

1. **Fix the review comment on #505** — the options table in `docs/configuration.rst` listed only 14 of the 21 default branch types and omitted `ai`, `claude`, `codex`, `copilot`, `cursor`, `dependabot`, `renovate` from the Default column. The Default column now lists the **full** `DEFAULT_BRANCH_TYPES` list.

2. **Make the spec deviation explicit** — `DEFAULT_BRANCH_TYPES` is a superset of the [Conventional Branch spec](https://conventionalbranch.org/): spec types (`feature`, `bugfix`, `hotfix`, `release`, `chore`) plus Conventional Commit types (`build`, `ci`, `docs`, `perf`, `refactor`, `style`, `test`) and AI/bot prefixes (`ai`, `claude`, `codex`, `copilot`, `cursor`, `dependabot`, `renovate`). The description column and both config examples (README + `docs/configuration.rst`) now state this explicitly, and point users to `allow_branch_types` for strict spec-only validation.

## Changes

- `README.md` — comment above `allow_branch_types` in the example config
- `docs/configuration.rst` — full default list in the Options table; expanded description with spec-superset note; example config reformatted to match the README (multi-line) with a clarifying comment

## Validation

- `sphinx-build -E -b html docs _build/html` succeeds; no new warnings (existing 7 warnings are pre-existing in `changelog.rst`/`migration.rst`)
- Options table renders all 21 default types

Closes #494
