### PR TITLE
docs: move documentation links to the project domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pip install git+https://github.com/commit-check/commit-check.git@main
 ```
 
 Then, run `commit-check --help` or `cchk --help` (alias for `commit-check`) from the command line.
-For more information, see the [docs](https://commit-check.github.io/commit-check/cli_args.html).
+For more information, see the [docs](https://docs.commit-check.com/cli_args.html).
 
 ## Configuration
 
@@ -209,7 +209,7 @@ repos:
           - --author-email-pattern=^.+@example\.com$
 ```
 
-See the [Configuration documentation](https://commit-check.github.io/commit-check/configuration.html) for all available options.
+See the [Configuration documentation](https://docs.commit-check.com/configuration.html) for all available options.
 
 ### Check Push Safety
 
@@ -377,7 +377,7 @@ Available API functions:
 - `validate_author(name=None, email=None, *, config=None)` — validate author name/email
 - `validate_all(message, branch, author_name, author_email, *, config=None)` — run all checks at once
 
-For detailed usage instructions including pre-commit hooks, CLI commands, and STDIN examples, see the [Usage Examples documentation](https://commit-check.github.io/commit-check/example.html).
+For detailed usage instructions including pre-commit hooks, CLI commands, and STDIN examples, see the [Usage Examples documentation](https://docs.commit-check.com/example.html).
 
 ## Examples
 
@@ -423,7 +423,7 @@ The branch should follow Conventional Branch. See https://conventionalbranch.org
 Suggest: Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass
 ```
 
-More examples see [example documentation](https://commit-check.github.io/commit-check/example.html).
+More examples see [example documentation](https://docs.commit-check.com/example.html).
 
 ## Badging your repository
 

--- a/docs/what-is-new.rst
+++ b/docs/what-is-new.rst
@@ -121,7 +121,7 @@ ancestry via ``git merge-base --is-ancestor``.
     print(result["status"])  # "pass"
 
 See the `Push Safety section in README <https://github.com/commit-check/commit-check#check-push-safety>`_
-and `Push Validation Examples <https://commit-check.github.io/commit-check/example.html#push-validation-examples>`_
+and `Push Validation Examples <https://docs.commit-check.com/example.html#push-validation-examples>`_
 for more details.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ commit-check = "commit_check.main:main"
 cchk = "commit_check.main:main"  # short alias without clobbering system cc
 
 [project.urls]
-documentation = "https://commit-check.github.io/commit-check/"
+documentation = "https://docs.commit-check.com/"
 source = "https://github.com/commit-check/commit-check"
 tracker = "https://github.com/commit-check/commit-check/issues"
 


### PR DESCRIPTION
## Summary

The documentation is now served from its own domain, so point the remaining `github.io` links at it.

| Location | Change |
| --- | --- |
| `README.md` (4 links) | `commit-check.github.io/commit-check/…` → `docs.commit-check.com/…` |
| `pyproject.toml` | `documentation` URL → `https://docs.commit-check.com/` |
| `docs/what-is-new.rst` | example link → `docs.commit-check.com` |

The `documentation` URL in `pyproject.toml` is what PyPI shows on the project page, so this also updates where package users land.

## Notes

- Existing links keep working: GitHub Pages redirects the old `github.io` URLs to the custom domain, so nothing already published breaks.
- The rules reference link that ships in commit-check's own output was set to the new domain separately, in #512.

## Testing

Full test suite passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EP4xvwiuE98BeYSpe7EbyB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation, configuration, API, examples, and push-safety links to the new documentation site.
  - Updated the project’s official documentation URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->