### PR TITLE
docs: update documentation links to commit-check.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/__pycache__
 # MkDocs
 site/
 docs/cli.md
+
+# Social card cache written by the docs build
+.cache/

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pip install git+https://github.com/commit-check/commit-check.git@main
 ```
 
 Then, run `commit-check --help` or `cchk --help` (alias for `commit-check`) from the command line.
-For more information, see the [docs](https://docs.commit-check.com/cli_args.html).
+For more information, see the [docs](https://commit-check.com/configuration/).
 
 ## Configuration
 
@@ -209,7 +209,7 @@ repos:
           - --author-email-pattern=^.+@example\.com$
 ```
 
-See the [Configuration documentation](https://docs.commit-check.com/configuration.html) for all available options.
+See the [Configuration documentation](https://commit-check.com/configuration/) for all available options.
 
 ### Check Push Safety
 
@@ -377,7 +377,7 @@ Available API functions:
 - `validate_author(name=None, email=None, *, config=None)` — validate author name/email
 - `validate_all(message, branch, author_name, author_email, *, config=None)` — run all checks at once
 
-For detailed usage instructions including pre-commit hooks, CLI commands, and STDIN examples, see the [Usage Examples documentation](https://docs.commit-check.com/example.html).
+For detailed usage instructions including pre-commit hooks, CLI commands, and STDIN examples, see the [Usage Examples documentation](https://commit-check.com/example/).
 
 ## Examples
 
@@ -423,7 +423,7 @@ The branch should follow Conventional Branch. See https://conventionalbranch.org
 Suggest: Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass
 ```
 
-More examples see [example documentation](https://docs.commit-check.com/example.html).
+For more examples, see the [example documentation](https://commit-check.com/example/).
 
 ## Badging your repository
 

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 #: Base URL of the rules reference documentation.
-RULES_DOCS_URL = "https://docs.commit-check.com/rules/"
+RULES_DOCS_URL = "https://commit-check.com/rules/"
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ commit-check = "commit_check.main:main"
 cchk = "commit_check.main:main"  # short alias without clobbering system cc
 
 [project.urls]
-documentation = "https://docs.commit-check.com/"
+documentation = "https://commit-check.com/"
 source = "https://github.com/commit-check/commit-check"
 tracker = "https://github.com/commit-check/commit-check/issues"
 

--- a/tests/rules_catalog_test.py
+++ b/tests/rules_catalog_test.py
@@ -66,6 +66,18 @@ class TestRuleIds:
         assert entry.docs_url == f"{RULES_DOCS_URL}#cc003"
 
     @pytest.mark.benchmark
+    def test_docs_url_points_at_the_published_site(self):
+        """The base URL is pinned, not just derived.
+
+        Every failure the tool reports carries this URL, and released versions
+        keep printing whatever they shipped with, so a wrong value cannot be
+        corrected after the fact. The other tests build their expectations from
+        ``RULES_DOCS_URL`` and would follow it anywhere, including back to a
+        host that no longer serves the documentation.
+        """
+        assert RULES_DOCS_URL == "https://commit-check.com/rules/"
+
+    @pytest.mark.benchmark
     def test_no_docs_url_without_id(self):
         """An entry without a rule ID has no docs URL to link to."""
         assert RuleCatalogEntry(check="ignore_authors").docs_url is None


### PR DESCRIPTION
The documentation moved to [commit-check/commit-check.com](https://github.com/commit-check/commit-check.com), where it is served from the apex domain alongside the landing page and the blog.

This is the URL-only half of the migration. It is safe to merge before the new site is live, because `docs.commit-check.com` keeps serving until it is retired.

### Changes

| File | Change |
| --- | --- |
| `commit_check/rules_catalog.py` | `RULES_DOCS_URL` → `https://commit-check.com/rules/` |
| `pyproject.toml` | `documentation` project URL |
| `README.md` | 4 links, also moved off the Sphinx-era `.html` URLs |

`RULES_DOCS_URL` is the one that matters. It is embedded in every failure message the tool prints, so it has to be right **before the next release makes it permanent**. It has not shipped to PyPI yet, which is the only reason changing it is still free.

The CLI reference page no longer exists — the flags it listed are documented alongside the settings that control them — so `cli_args.html` now points at the configuration page.

### Not in this PR

Removing `docs/`, `mkdocs.yml`, `netlify.toml`, the `docs` CI job and the six documentation-consistency tests. Doing that before the new site has DNS and Pages configured would leave a window with no documentation on either domain, so it wants a separate change once `commit-check.com` is verified live.

### Verification

`460 passed, 1 failed` — the failure is `test_load_config_file_permission_error`, which uses `os.chmod(0o000)` and cannot fail as root; it is unrelated to this change and fails the same way on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation links to use the new `commit-check.com` domain.
  * Refreshed links for installation, configuration, usage examples, and rule documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->