### PR TITLE
docs: add commit-check.com link to config header

### DIFF
--- a/cchk.toml
+++ b/cchk.toml
@@ -1,3 +1,5 @@
+# Learn more: https://commit-check.com
+
 [commit]
 # https://www.conventionalcommits.org
 conventional_commits = true


### PR DESCRIPTION
Adds the official website link at the top of `cchk.toml` to increase site exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference link to commit-check.com in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->