### PR TITLE
fix: print the display name in compact output, not the config key

### DIFF
--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -24,6 +24,22 @@ from dataclasses import dataclass
 RULES_DOCS_URL = "https://commit-check.com/rules/"
 
 
+def display_name(check: str) -> str:
+    """Human-readable form of a check name, e.g. ``subject-imperative``.
+
+    Config files and the JSON output carry the snake_case key, because that is
+    what a reader sets in ``cchk.toml`` and what a consumer maps back to an
+    option. Text written for a person uses the kebab-case form instead: it is
+    how the rules reference titles each rule, so a name printed to a terminal
+    can be searched for there verbatim.
+
+    Every text surface goes through here so the two forms cannot drift apart
+    again — the compact output once printed the config key while the default
+    output printed this one.
+    """
+    return check.replace("_", "-")
+
+
 @dataclass(frozen=True)
 class RuleCatalogEntry:
     check: str
@@ -35,7 +51,7 @@ class RuleCatalogEntry:
     @property
     def name(self) -> str:
         """Human-readable rule name, e.g. ``subject-imperative``."""
-        return self.check.replace("_", "-")
+        return display_name(self.check)
 
     @property
     def docs_url(self) -> str | None:

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -13,6 +13,22 @@ from subprocess import CalledProcessError
 from commit_check import RED, GREEN, YELLOW, RESET_COLOR
 
 
+def display_name(check_type: str) -> str:
+    """Human-readable form of a check name, e.g. ``subject-imperative``.
+
+    Config files and the JSON output carry the snake_case key, because that is
+    what a reader sets in ``cchk.toml`` and what a consumer maps back to an
+    option. Text written for a person uses the kebab-case form instead: it is
+    how the rules reference titles each rule, so a name printed to a terminal
+    can be searched for there verbatim.
+
+    Every text surface goes through here so the two forms cannot drift apart
+    again — the compact output once printed the config key while the default
+    output printed this one.
+    """
+    return check_type.replace("_", "-")
+
+
 def _print_failure(
     check: dict,
     actual: str,
@@ -23,7 +39,8 @@ def _print_failure(
     rule_id = check.get("rule_id", "")
     if compact:
         compact_value = actual.splitlines()[0] if actual else actual
-        label = f"{rule_id} {check['check']}" if rule_id else check["check"]
+        name = display_name(check["check"])
+        label = f"{rule_id} {name}" if rule_id else name
         print(f"[FAIL] {label}: {compact_value}")
         return
     if not no_banner and not print_error_header.has_been_called:
@@ -364,9 +381,7 @@ def print_error_message(
 
     :returns: Give error messages to user
     """
-    # The kebab-case form is what the rules reference uses as its headings, so
-    # the name printed here can be searched for there verbatim.
-    name = check_type.replace("_", "-")
+    name = display_name(check_type)
     label = rule_id
     if rule_id and docs_url and supports_hyperlinks():
         label = hyperlink(rule_id, docs_url)

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -11,22 +11,7 @@ import subprocess
 import sys
 from subprocess import CalledProcessError
 from commit_check import RED, GREEN, YELLOW, RESET_COLOR
-
-
-def display_name(check_type: str) -> str:
-    """Human-readable form of a check name, e.g. ``subject-imperative``.
-
-    Config files and the JSON output carry the snake_case key, because that is
-    what a reader sets in ``cchk.toml`` and what a consumer maps back to an
-    option. Text written for a person uses the kebab-case form instead: it is
-    how the rules reference titles each rule, so a name printed to a terminal
-    can be searched for there verbatim.
-
-    Every text surface goes through here so the two forms cannot drift apart
-    again — the compact output once printed the config key while the default
-    output printed this one.
-    """
-    return check_type.replace("_", "-")
+from commit_check.rules_catalog import display_name
 
 
 def _print_failure(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -729,6 +729,35 @@ class TestCompact:
         assert len(lines) >= 1
 
     @pytest.mark.benchmark
+    def test_compact_names_checks_the_way_the_default_output_does(
+        self, mocker, capsys, monkeypatch
+    ):
+        """--compact prints the kebab-case name, not the config key.
+
+        Both are text written for a person, so they have to agree. This
+        assertion is the one the suite was missing: --compact shipped
+        printing ``subject_imperative`` while the default output printed
+        ``subject-imperative``, and nothing here noticed.
+        """
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="docs: revamped the profile\n")
+        mocker.patch("commit_check.engine.get_commit_info", return_value="test-author")
+
+        # A check whose name contains an underscore, so the two forms differ.
+        monkeypatch.setattr(
+            "sys.argv", [CMD, "-m", "--compact", "--subject-imperative=true"]
+        )
+        main()
+
+        out, _ = capsys.readouterr()
+        assert "CC003 subject-imperative:" in out, (
+            f"--compact should print the display name: {out!r}"
+        )
+        assert "subject_imperative" not in out, (
+            f"--compact printed the config key: {out!r}"
+        )
+
+    @pytest.mark.benchmark
     def test_compact_no_suggestions(self, mocker, capsys, monkeypatch):
         """--compact output must not include 'Suggest:' lines."""
         mocker.patch("sys.stdin.isatty", return_value=False)


### PR DESCRIPTION
Fixes #528.

## What

The same failing check is named two ways depending on the format:

```console
$ echo "docs: revamped the profile" | commit-check -m --subject-imperative=true --no-banner
CC003 subject-imperative check failed ==> docs: revamped the profile

$ echo "docs: revamped the profile" | commit-check -m --subject-imperative=true --compact
[FAIL] CC003 subject_imperative: docs: revamped the profile
```

Both are text written for a person, so they should agree.

## Why kebab, and why JSON stays as it is

The two conventions each have a job, and only one surface was on the wrong side of the line:

| Surface | Form | Converts? |
|---|---|---|
| Default text | `subject-imperative` | yes, in `print_error_message` |
| `commit-check-action` step log, job summary, PR comment | `subject-imperative` | yes, in its own `_rule_label` |
| `--format json`, `check` field | `subject_imperative` | no — and correctly so |
| `--compact` | `subject_imperative` | **no** |

Kebab is the form the rules reference titles each rule with (`### subject-imperative (CC003)`), so a name printed to a terminal can be pasted into the docs and found. That is already why the default output converts.

The JSON `check` field is deliberately untouched: it carries the snake_case key so a consumer can map a failure back to the `cchk.toml` option that controls it. `commit-check-action` depends on exactly that — it takes the raw key and converts it itself for display, which is the clearest evidence that the display form is meant to be kebab throughout.

## The change

Both call sites now go through one `display_name()` helper instead of one of them open-coding `.replace("_", "-")`. That open-coding is how the two drifted apart in the first place, so a shared helper is the part that stops it recurring.

## Compatibility

`--compact` landed in 2.6.0 and is described as being for CI logs. The format of the line is unchanged — only the check name's spelling. The machine-readable path, `--format json`, is untouched.

The one risk worth naming: anyone grepping `subject_imperative` out of `--compact` output would need to grep `subject-imperative` instead. Whether that is worth a minor or a major is your call — I have no way to see how the flag is used in the wild.

## Test plan

A new test asserts the form both text outputs print. The suite had no such assertion, which is how this shipped: `test_compact_shows_one_line_per_failure` only checks that each line starts with `[FAIL]`.

Verified by reverting the fix and confirming the test fails:

```
E  assert 'CC003 subject-imperative:' in '[FAIL] CC003 subject_imperative: docs: revamped the profile\n'
```

Worth noting, because my first attempt at this test passed against the broken code: it asserted on the default `-m` run, whose failing check is `message` — a name with no underscore, so the two forms are identical and the assertion could not discriminate. The test now drives `--subject-imperative=true` specifically to get a name that differs between the forms.

Full suite: 506 passed. Two failures are pre-existing on unmodified `main` in this environment and unrelated to this change — `test_load_config_file_permission_error` (does not raise when the suite runs as root) and `TestAiAttributionValidator::test_empty_message_passes`.

## Note on the branch name

`AGENTS.md` asks for a Conventional Branch type, and `claude/` is not in the list it gives — my session is pinned to this branch name. The repository's own `cchk.toml` sets `conventional_branch = false`, so CI does not enforce it, and `claude/` is in the tool's own default allow-list. Happy to move it if you would rather it read `fix/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Check names are now displayed consistently in kebab-case across compact failure output and standard error messages.
  - Corrected output for checks configured with underscore-based names.

- **Tests**
  - Added regression coverage to verify compact output uses the expected check names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->