### PR TITLE
ci: run commit-check on every PR, and check the title as it will land

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -34,7 +34,7 @@ jobs:
       # The action rather than a nox session: this repository is what the
       # action installs, so running it here is the project checking itself
       # with the thing users actually run.
-      - uses: commit-check/commit-check-action@124de73e3d47e0b4c1a89f70bbe1f17138c191ce # v2.13.0
+      - uses: commit-check/commit-check-action@562a184b2b8e583e757b17eb385bc48370f44547 # v2.13.1
         with:
           message: true
           branch: true

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,0 +1,45 @@
+name: Commit Check
+
+permissions:
+  contents: read
+  pull-requests: write # pr-comments writes back to the pull request
+
+on:
+  # Pull requests only, deliberately.
+  #
+  # A push to main carries the squashed commit, whose subject is the pull
+  # request title with " (#N)" appended by GitHub. Checking there re-runs work
+  # that already passed, against a subject the author never wrote and cannot
+  # shorten — which is how #530 passed review at 75 characters and then failed
+  # on main at 82, against a limit of 80.
+  #
+  # No `paths:` filter either. A subject, a branch name or an author address is
+  # wrong regardless of which files the change touches, and the filter on
+  # main.yml is why nothing ran on #530 at all: it changed only assets/.
+  #
+  # `edited` matters: a squash merge turns the title into the commit subject,
+  # so retitling a pull request changes what will be committed.
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  commit-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0 # full history, so branch and rebase checks can resolve
+          # Nothing after checkout needs authenticated git.
+          persist-credentials: false
+      # The action rather than a nox session: this repository is what the
+      # action installs, so running it here is the project checking itself
+      # with the thing users actually run.
+      - uses: commit-check/commit-check-action@124de73e3d47e0b4c1a89f70bbe1f17138c191ce # v2.13.0
+        with:
+          message: true
+          branch: true
+          author-name: true
+          author-email: true
+          pr-title: true # the subject a squash merge will commit
+          job-summary: true
+          pr-comments: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,6 @@ jobs:
         with:
           name: commit-check_wheel
           path: ${{ github.workspace }}/dist/*.whl
-      - name: Run commit-check
-        run: nox -s commit-check
-
       - name: Collect Coverage
         run: nox -s coverage
 


### PR DESCRIPTION
## What

Two workflow files, plus the action pin that made this PR green.

- **Add `.github/workflows/commit-check.yml`**: runs [commit-check-action](https://github.com/commit-check/commit-check-action) on **pull requests only** (`opened, synchronize, reopened, edited`), with `pr-title: true` so the title is checked as the subject a squash merge will actually commit. No `paths:` filter. Action SHA-pinned like every other action in this repo.
- **Remove the `Run commit-check` step from `main.yml`**: the push-to-main check is gone entirely.

## Why

#530 passed review with a 75-character title and failed commit-check **on main** at 82/80 — the squash merge appended ` (#530)` and pushed the subject over the limit. Nothing had run on the PR itself:

1. `main.yml`'s `paths:` filter skipped the check — #530 touched only `assets/`.
2. The nox session checked `HEAD`, never the title a squash merge would commit.
3. The push-to-main run then re-checked already-approved work against a subject the author never wrote and cannot shorten.

Checking only pull requests removes the failure mode instead of predicting it: the title is checked once, where it can still be edited, and `edited` re-checks on retitle. This is also the project checking itself with the thing users actually run.

## CC202 — resolved

This PR carried a false **CC202 merge-base** failure from its first run. The engine the pinned action installed could not resolve a rebase target that exists only as `origin/main` in a PR checkout, so it reported "not rebased" for a branch that was.

That it was the engine and not the branch is now established rather than argued: the branch was rebased onto `main` while CC202 still failed, with `git merge-base --is-ancestor origin/main HEAD` returning true throughout.

The fix was the pin. **The action's version does not track the engine's**, which is the part worth reading `requirements.txt` for rather than inferring:

| action tag | SHA | installs |
|---|---|---|
| v2.13.0 | `124de73` | `commit-check==2.13.1` — the buggy engine |
| **v2.13.1** | `562a184` | **`commit-check==2.13.4`** — carries #532's fix |

A patch bump on the action jumps the engine three releases. `commit-check` is now green, and the check's own footer confirms which engine ran (`commit-check 2.13.4`).

Two behaviours ride along on the newer engine:

- **Skipped checks report as skipped** (#537), so a run bypassed by `ignore_authors` says so instead of showing green ticks over nothing validated.
- **The imperative whitelist goes 396 → 529 verbs**, retiring a class of false CC003. The old engine rejected `treat`, which #527 had added three releases earlier.

## Worth knowing before merging: `edited` doubles the CI cost

Measured on this PR's own run history, duplicate runs land on every SHA:

| SHA | `commit-check` runs |
|---|---|
| `93bf2ef` | 2 |
| `e481ae8` | 2 |
| `02bd378` | 3 |

`edited` fires on **description** edits, not just title edits, and CodeRabbit edits the description on every review to insert its summary — so each review costs an extra full run. `edited` is still needed (a retitle must re-check `pr-title`), but GitHub offers no title-only filter. Gating the job would keep the retitle re-check and drop the rest:

```yaml
if: github.event.action != 'edited' || github.event.changes.title != null
```

Not applied here — flagging it as a follow-up decision for the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn