### PR TITLE
fix: stop the release from trying to publish its dependencies

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,10 +28,22 @@ jobs:
         # Install dependencies
         python -m pip install --only-binary :all: --upgrade pip
         python -m pip install --only-binary :all: ".[ci]"
-        # Build wheel
-        python -m pip wheel -w dist .
+        # Build wheel. --no-deps matters: without it pip also resolves and
+        # writes every dependency's wheel into dist/, and the publish step
+        # below uploads the whole directory, so PyPI is asked to accept
+        # someone else's package under our project-scoped token.
+        python -m pip wheel --no-deps -w dist .
         # Check distribution
         twine check dist/commit_check*
+        # The publish step has no way to select files, so dist/ being ours
+        # alone is a precondition it cannot check for itself. Fail here, with
+        # a message that names the problem, rather than at the upload with a
+        # 403 about a project we do not own.
+        foreign=$(find dist -mindepth 1 -not -name 'commit_check-*' -printf '%f\n')
+        if [ -n "$foreign" ]; then
+          echo "::error::dist/ must contain only commit-check artifacts, found: $foreign"
+          exit 1
+        fi
 
     - name: Create attestations
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -35,13 +35,18 @@ jobs:
         python -m pip wheel --no-deps -w dist .
         # Check distribution
         twine check dist/commit_check*
-        # The publish step has no way to select files, so dist/ being ours
-        # alone is a precondition it cannot check for itself. Fail here, with
-        # a message that names the problem, rather than at the upload with a
-        # 403 about a project we do not own.
-        foreign=$(find dist -mindepth 1 -not -name 'commit_check-*' -printf '%f\n')
+        # The publish step has no way to select files, so dist/ holding
+        # exactly what we mean to upload is a precondition it cannot check
+        # for itself. Fail here, with a message that names the problem,
+        # rather than at the upload with a 403 about a project we do not own.
+        #
+        # This names our own wheels specifically, not merely "not someone
+        # else's": a release that starts producing anything else -- an sdist,
+        # a stray file, a leftover directory -- should stop here and be
+        # looked at, not be uploaded because it happened to carry our prefix.
+        foreign=$(find dist -mindepth 1 \( ! -type f -o ! -name 'commit_check-*.whl' \) -printf '%f\n')
         if [ -n "$foreign" ]; then
-          echo "::error::dist/ must contain only commit-check artifacts, found: $foreign"
+          echo "::error::dist/ must contain only commit-check wheels, found: $foreign"
           exit 1
         fi
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -28,27 +28,13 @@ jobs:
         # Install dependencies
         python -m pip install --only-binary :all: --upgrade pip
         python -m pip install --only-binary :all: ".[ci]"
-        # Build wheel. --no-deps matters: without it pip also resolves and
-        # writes every dependency's wheel into dist/, and the publish step
-        # below uploads the whole directory, so PyPI is asked to accept
-        # someone else's package under our project-scoped token.
+        # Build wheel. --no-deps is load-bearing: without it pip also writes
+        # every dependency's wheel into dist/, and the publish step uploads
+        # the whole directory (it has no file-selection input), so PyPI is
+        # asked to accept someone else's package under our scoped token.
         python -m pip wheel --no-deps -w dist .
         # Check distribution
         twine check dist/commit_check*
-        # The publish step has no way to select files, so dist/ holding
-        # exactly what we mean to upload is a precondition it cannot check
-        # for itself. Fail here, with a message that names the problem,
-        # rather than at the upload with a 403 about a project we do not own.
-        #
-        # This names our own wheels specifically, not merely "not someone
-        # else's": a release that starts producing anything else -- an sdist,
-        # a stray file, a leftover directory -- should stop here and be
-        # looked at, not be uploaded because it happened to carry our prefix.
-        foreign=$(find dist -mindepth 1 \( ! -type f -o ! -name 'commit_check-*.whl' \) -printf '%f\n')
-        if [ -n "$foreign" ]; then
-          echo "::error::dist/ must contain only commit-check wheels, found: $foreign"
-          exit 1
-        fi
 
     - name: Create attestations
       uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1


### PR DESCRIPTION
## The failure

[Run 31178652101](https://github.com/commit-check/commit-check/actions/runs/31178652101) (v2.13.4):

```
Uploading pyyaml-6.0.3-cp314-cp314-manylinux_2_28_x86_64.whl
403 Invalid API Token: project-scoped token is not valid for project: 'PyYAML'
```

The release is trying to upload **PyYAML** to PyPI. The token is scoped to `commit-check`, so PyPI refuses — correctly.

## It is not new: ten consecutive releases have failed

| run | tag | result |
|---|---|---|
| 81 | v2.13.4 | ❌ |
| 80 | v2.13.3 | ❌ |
| 79 | v2.13.2 | ❌ |
| 78 | v2.13.1 | ❌ |
| 77 | v2.13.0 | ❌ |
| 76 | v2.12.2 | ❌ |
| 75 | v2.12.1 | ❌ |
| 74 | v2.12.0 | ❌ |
| 73 | v2.11.1 | ❌ |
| 72 | v2.11.0 | ❌ |
| 71 | v2.10.1 | ✅ |

**Nobody noticed because the release still works.** Uploads happen file by file and `commit_check-*` sorts before `pyyaml-*`, so our wheel lands on PyPI and *then* the job goes red on someone else's package. The artefact ships; only the workflow looks broken — a state that is easy to keep ignoring, and was, ten times.

## Root cause

`pip wheel` resolves and writes a wheel for the project **and every dependency**. Reproduced locally against this tree:

```console
$ pip wheel -w dist .
commit_check-2.13.4-py3-none-any.whl
pyyaml-6.0.3-cp311-...-manylinux_2_28_x86_64.whl     ← not ours
```

That was harmless while the upload named what it wanted. #453 (v2.11.0) migrated from `twine` to `pypa/gh-action-pypi-publish`, and the scoping was lost in the move:

```diff
-      run: twine upload dist/commit_check*
+      uses: pypa/gh-action-pypi-publish@...
```

The action has **no file-selection input** — it uploads the whole directory. The two steps in between (`twine check dist/commit_check*` and the attestation's `subject-path: dist/commit_check*`) kept their globs, which is why they still pass and why the mismatch went unseen.

## The fix

One word:

```diff
-python -m pip wheel -w dist .
+python -m pip wheel --no-deps -w dist .
```

```console
$ pip wheel --no-deps -w dist .
commit_check-2.13.4-py3-none-any.whl
```

An earlier revision of this PR also added a guard that failed the build when `dist/` held anything else. It was dropped on review: it was two thirds of the diff, guarding a flag that now carries a comment explaining why it exists, and it introduced a fresh way for a release to fail (`find -printf` is GNU-only, and any false positive would block publishing outright). The flag is the fix; the comment is the protection.

## Separate finding, deliberately not fixed here

This workflow has **only ever published wheels**. `pip wheel` produces no sdist, and PyPI confirms none exists for any version:

```console
$ curl -s https://pypi.org/pypi/commit-check/2.13.3/json | jq '[.urls[].packagetype] | unique'
["bdist_wheel"]
```

Switching the build to `python -m build` would produce an sdist as well and also fix this bug — but it changes what a release contains, which deserves its own PR and its own decision rather than riding along with an outage fix.

## After merging

v2.13.4 is already on PyPI (the wheel uploaded before the 403), so nothing needs re-releasing. The next release should be the first green publish since June.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn