### PR TITLE
feat: check imperative mood by form rather than by vocabulary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,8 @@ repos:
     -   id: codespell
         # iTerm is a terminal emulator, named in the hyperlink support probe.
         # "sting" is a real verb, listed in NON_IMPERATIVE_LOOKALIKES.
-        args: [--ignore-words-list=iterm,sting]
+        # Quoted: an unquoted comma splits the flow sequence into two args.
+        args: ["--ignore-words-list=iterm,sting"]
 -   repo: https://github.com/commit-check/commit-check
     rev: v2.11.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,8 @@ repos:
     hooks:
     -   id: codespell
         # iTerm is a terminal emulator, named in the hyperlink support probe.
-        args: [--ignore-words-list=iterm]
+        # "sting" is a real verb, listed in NON_IMPERATIVE_LOOKALIKES.
+        args: [--ignore-words-list=iterm,sting]
 -   repo: https://github.com/commit-check/commit-check
     rev: v2.11.0
     hooks:

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -24,7 +24,7 @@ from commit_check.util import (
     git_merge_base,
     git_rev_parse_verify,
 )
-from commit_check.imperatives import IMPERATIVES
+from commit_check.imperatives import IMPERATIVES, NON_IMPERATIVE_LOOKALIKES
 
 
 class ValidationResult(IntEnum):
@@ -392,7 +392,42 @@ class SubjectCapitalizationValidator(SubjectValidator):
 
 
 class SubjectImperativeValidator(SubjectValidator):
-    """Validates that subject uses imperative mood."""
+    """Validates that subject uses imperative mood.
+
+    Asks whether the first word is in a form that is *not* imperative, rather
+    than whether it appears in a list of words that are.
+
+    The list came first and could not work. Imperative mood is a property of
+    a word's form, not of its membership in a vocabulary, so any list is an
+    approximation that rejects correct subjects wherever it falls short --
+    and it always falls short. Measured against 40,000 subjects from git.git,
+    a project that writes strictly imperative subjects, a 396-word list
+    rejected 17.9%; growing it to 529 words still rejected 10.5%. Each
+    release recognised a few more verbs and the next contributor found the
+    next gap. See #526.
+
+    Morphology decides it in three rules and no vocabulary: a past tense
+    (``fixed``), a gerund (``adding``) or a third-person singular
+    (``fixes``) is not an imperative, and nothing else in a leading position
+    is disqualifying. That is also the only thing this rule was ever meant to
+    catch, so a rejection now means the author really did write "fixed".
+
+    Two allow-lists survive, both as fast paths rather than as the decision:
+    :data:`IMPERATIVES` for known verbs, and
+    :data:`NON_IMPERATIVE_LOOKALIKES` for the few words whose spelling trips
+    the morphology (``embed``, ``bring``, ``focus``) and the adverbs that can
+    lead an imperative subject (``always quote the path``).
+
+    The loosening is deliberate: a subject led by a noun ("parser
+    improvements") now passes, where the list would have rejected it. Mood is
+    what this rule is named for, and a list of verbs was never a reliable way
+    to catch a missing one.
+    """
+
+    #: Suffixes that mark a word as inflected rather than imperative. ``-ss``
+    #: is excluded from the third-person test because ``address`` and
+    #: ``process`` end that way while being perfectly good imperatives.
+    _INFLECTED = ("ed", "ing")
 
     def _validate_subject(self, subject: str) -> ValidationResult:
         # Skip merge commits and fixup commits
@@ -408,11 +443,26 @@ class SubjectImperativeValidator(SubjectValidator):
             return ValidationResult.PASS
 
         first_word = match.group(1).lower()
-        if first_word in IMPERATIVES:
+
+        # Fast paths: a known imperative verb, or one of the few words whose
+        # spelling would trip the morphology test below.
+        if first_word in IMPERATIVES or first_word in NON_IMPERATIVE_LOOKALIKES:
             return ValidationResult.PASS
 
-        self._print_failure(subject)
-        return ValidationResult.FAIL
+        if self._is_inflected(first_word):
+            self._print_failure(subject)
+            return ValidationResult.FAIL
+
+        return ValidationResult.PASS
+
+    @classmethod
+    def _is_inflected(cls, word: str) -> bool:
+        """Whether *word* carries past-tense, gerund or third-person marking."""
+        if word.endswith(cls._INFLECTED):
+            return True
+        # Third-person singular. "address" and "guess" end in s without being
+        # one, and every such word in English doubles the s.
+        return word.endswith("s") and not word.endswith("ss")
 
 
 class SubjectLengthValidator(SubjectValidator):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -394,39 +394,17 @@ class SubjectCapitalizationValidator(SubjectValidator):
 class SubjectImperativeValidator(SubjectValidator):
     """Validates that subject uses imperative mood.
 
-    Asks whether the first word is in a form that is *not* imperative, rather
-    than whether it appears in a list of words that are.
+    Decides on the first word's form rather than its membership in a
+    vocabulary: a past tense ("fixed"), a gerund ("adding") or a third person
+    ("fixes") is not imperative, and nothing else disqualifies. A list can
+    only reject correct subjects wherever it falls short, and it always does:
+    on 59k strictly imperative subjects from git.git it rejected 45%, against
+    1% here. See #526.
 
-    The list came first and could not work. Imperative mood is a property of
-    a word's form, not of its membership in a vocabulary, so any list is an
-    approximation that rejects correct subjects wherever it falls short --
-    and it always falls short. Measured against 40,000 subjects from git.git,
-    a project that writes strictly imperative subjects, a 396-word list
-    rejected 17.9%; growing it to 529 words still rejected 10.5%. Each
-    release recognised a few more verbs and the next contributor found the
-    next gap. See #526.
-
-    Morphology decides it in three rules and no vocabulary: a past tense
-    (``fixed``), a gerund (``adding``) or a third-person singular
-    (``fixes``) is not an imperative, and nothing else in a leading position
-    is disqualifying. That is also the only thing this rule was ever meant to
-    catch, so a rejection now means the author really did write "fixed".
-
-    Two allow-lists survive, both as fast paths rather than as the decision:
-    :data:`IMPERATIVES` for known verbs, and
-    :data:`NON_IMPERATIVE_LOOKALIKES` for the few words whose spelling trips
-    the morphology (``embed``, ``bring``, ``focus``) and the adverbs that can
-    lead an imperative subject (``always quote the path``).
-
-    The loosening is deliberate: a subject led by a noun ("parser
-    improvements") now passes, where the list would have rejected it. Mood is
-    what this rule is named for, and a list of verbs was never a reliable way
-    to catch a missing one.
+    The loosening is deliberate: a noun-led subject ("parser improvements")
+    now passes, where the list rejected it by accident of vocabulary.
     """
 
-    #: Suffixes that mark a word as inflected rather than imperative. ``-ss``
-    #: is excluded from the third-person test because ``address`` and
-    #: ``process`` end that way while being perfectly good imperatives.
     _INFLECTED = ("ed", "ing")
 
     def _validate_subject(self, subject: str) -> ValidationResult:
@@ -444,8 +422,7 @@ class SubjectImperativeValidator(SubjectValidator):
 
         first_word = match.group(1).lower()
 
-        # Fast paths: a known imperative verb, or one of the few words whose
-        # spelling would trip the morphology test below.
+        # Fast path, and the words whose spelling would trip the test below.
         if first_word in IMPERATIVES or first_word in NON_IMPERATIVE_LOOKALIKES:
             return ValidationResult.PASS
 
@@ -460,9 +437,26 @@ class SubjectImperativeValidator(SubjectValidator):
         """Whether *word* carries past-tense, gerund or third-person marking."""
         if word.endswith(cls._INFLECTED):
             return True
-        # Third-person singular. "address" and "guess" end in s without being
-        # one, and every such word in English doubles the s.
-        return word.endswith("s") and not word.endswith("ss")
+        return cls._is_third_person(word)
+
+    @classmethod
+    def _is_third_person(cls, word: str) -> bool:
+        """Whether *word* is a verb wearing the third-person singular -s.
+
+        Unlike -ed and -ing, a trailing -s is weak evidence on its own --
+        plural nouns wear one too ("status report") -- so it asks for
+        corroboration: the stem has to be a verb we already know. "tests" is
+        genuinely both, and this reads it as the verb.
+        """
+        # "address" and "process" end in -ss without being third person.
+        if not word.endswith("s") or word.endswith("ss"):
+            return False
+        stems = {word[:-1]}
+        if word.endswith("es"):
+            stems.add(word[:-2])
+        if word.endswith("ies"):
+            stems.add(word[:-3] + "y")
+        return any(stem in IMPERATIVES for stem in stems)
 
 
 class SubjectLengthValidator(SubjectValidator):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -422,10 +422,6 @@ class SubjectImperativeValidator(SubjectValidator):
 
         first_word = match.group(1).lower()
 
-        # Fast path, and the words whose spelling would trip the test below.
-        if first_word in IMPERATIVES or first_word in NON_IMPERATIVE_LOOKALIKES:
-            return ValidationResult.PASS
-
         if self._is_inflected(first_word):
             self._print_failure(subject)
             return ValidationResult.FAIL
@@ -435,6 +431,8 @@ class SubjectImperativeValidator(SubjectValidator):
     @classmethod
     def _is_inflected(cls, word: str) -> bool:
         """Whether *word* carries past-tense, gerund or third-person marking."""
+        if word in NON_IMPERATIVE_LOOKALIKES:
+            return False
         if word.endswith(cls._INFLECTED):
             return True
         return cls._is_third_person(word)

--- a/commit_check/imperatives.py
+++ b/commit_check/imperatives.py
@@ -547,19 +547,10 @@ IMPERATIVES = {
 }
 
 
-# Words the morphology rule in SubjectImperativeValidator would misread.
-#
-# That rule rejects a subject whose first word carries non-imperative
-# morphology -- a past tense, a gerund, or a third-person singular. English
-# spelling being what it is, a handful of words end in those letters without
-# being those forms, and they are the only cases the rule gets wrong. There
-# are few enough to enumerate honestly, which is why the check can rely on
-# shape rather than on a vocabulary of every imperative verb in the language.
-#
-# The adverbs are here rather than in IMPERATIVES on purpose. "always" is not
-# an imperative verb, and putting it in a set by that name would be a lie
-# about what the set contains; what is true is that "always quote the path"
-# is a correct imperative subject, and that the -s rule would reject it.
+# Imperative verbs that end in -ed or -ing without being a past tense or a
+# gerund, and so would be misread by the morphology rule in
+# SubjectImperativeValidator. Short enough to enumerate, which is what lets
+# that rule work on shape instead of on a vocabulary of every English verb.
 NON_IMPERATIVE_LOOKALIKES = {
     # -ed, but not a past tense
     "bleed",
@@ -587,10 +578,4 @@ NON_IMPERATIVE_LOOKALIKES = {
     "string",
     "swing",
     "wring",
-    # -s, but not a third-person singular. Words ending -ss are handled by
-    # the rule itself, so only the single-s ones need naming here.
-    "focus",
-    # adverbs that legitimately lead an imperative subject
-    "always",
-    "sometimes",
 }

--- a/commit_check/imperatives.py
+++ b/commit_check/imperatives.py
@@ -42,7 +42,6 @@ IMPERATIVES = {
     "authenticate",
     "authorise",
     "authorize",
-    "auto",
     "automate",
     "avoid",
     "await",
@@ -302,7 +301,6 @@ IMPERATIVES = {
     "parameterise",
     "parameterize",
     "parse",
-    "partial",
     "pass",
     "pause",
     "perform",
@@ -439,7 +437,6 @@ IMPERATIVES = {
     "serve",
     "set",
     "settle",
-    "setup",
     "shard",
     "shorten",
     "show",
@@ -549,6 +546,12 @@ IMPERATIVES = {
 # gerund, and so would be misread by the morphology rule in
 # SubjectImperativeValidator. Short enough to enumerate, which is what lets
 # that rule work on shape instead of on a vocabulary of every English verb.
+#
+# Both groups are meant to be the whole family rather than a sample of it --
+# a half-enumerated closed set would put back exactly the "add my word"
+# treadmill this check was rebuilt to escape. Err towards including a word:
+# an entry that never comes up costs nothing, a missing one rejects someone
+# who wrote correct English.
 NON_IMPERATIVE_LOOKALIKES = {
     # -ed, but not a past tense
     "bleed",
@@ -556,6 +559,7 @@ NON_IMPERATIVE_LOOKALIKES = {
     "embed",
     "exceed",
     "feed",
+    "heed",
     "need",
     "proceed",
     "seed",
@@ -564,16 +568,22 @@ NON_IMPERATIVE_LOOKALIKES = {
     "speed",
     "spread",
     "succeed",
+    "wed",
+    "weed",
     # -ing, but not a gerund
     "bring",
     "cling",
+    "ding",
     "fling",
     "ping",
     "ring",
     "sing",
+    "sling",
     "spring",
     "sting",
     "string",
     "swing",
+    "wing",
     "wring",
+    "zing",
 }

--- a/commit_check/imperatives.py
+++ b/commit_check/imperatives.py
@@ -2,17 +2,15 @@
 # https://github.com/crate-ci/imperative/blob/master/assets/imperatives.txt
 # and extended since.
 #
-# Some of these are more commonly encountered as nouns, but leaving them out
-# rejects a subject that is written correctly, which is the worse failure: the
-# contributor has to reword something that was never wrong, and the only way
-# they learn which words are acceptable is by trial and error.
+# This is NOT an allow-list, and a subject is never rejected for being absent
+# from it. CC003 decides on the word's form (see SubjectImperativeValidator),
+# and the only thing this set is still consulted for is the stem test behind
+# the third-person -s rule: "fixes" is a verb because "fix" is in here, while
+# "status" is not, because dropping its -s leaves nothing this set contains.
 #
-# For the same reason both spellings of every -ize/-ise verb are listed. A
-# project writing British English is not making a mistake.
-#
-# Additions are welcome and cheap. The list can only ever approximate "is this
-# an English imperative verb", so treat a rejected-but-correct subject as a bug
-# in this file rather than as something the author should work around.
+# So a missing verb costs a missed violation, never a false rejection -- there
+# is nothing to keep up with, and no need to send a patch adding the verb you
+# just used. Additions still help the -s rule catch more, and cost nothing.
 
 IMPERATIVES = {
     "abort",

--- a/commit_check/imperatives.py
+++ b/commit_check/imperatives.py
@@ -545,3 +545,52 @@ IMPERATIVES = {
     "yield",
     "zip",
 }
+
+
+# Words the morphology rule in SubjectImperativeValidator would misread.
+#
+# That rule rejects a subject whose first word carries non-imperative
+# morphology -- a past tense, a gerund, or a third-person singular. English
+# spelling being what it is, a handful of words end in those letters without
+# being those forms, and they are the only cases the rule gets wrong. There
+# are few enough to enumerate honestly, which is why the check can rely on
+# shape rather than on a vocabulary of every imperative verb in the language.
+#
+# The adverbs are here rather than in IMPERATIVES on purpose. "always" is not
+# an imperative verb, and putting it in a set by that name would be a lie
+# about what the set contains; what is true is that "always quote the path"
+# is a correct imperative subject, and that the -s rule would reject it.
+NON_IMPERATIVE_LOOKALIKES = {
+    # -ed, but not a past tense
+    "bleed",
+    "breed",
+    "embed",
+    "exceed",
+    "feed",
+    "need",
+    "proceed",
+    "seed",
+    "shed",
+    "shred",
+    "speed",
+    "spread",
+    "succeed",
+    # -ing, but not a gerund
+    "bring",
+    "cling",
+    "fling",
+    "ping",
+    "ring",
+    "sing",
+    "spring",
+    "sting",
+    "string",
+    "swing",
+    "wring",
+    # -s, but not a third-person singular. Words ending -ss are handled by
+    # the rule itself, so only the single-s ones need naming here.
+    "focus",
+    # adverbs that legitimately lead an imperative subject
+    "always",
+    "sometimes",
+}

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2560,3 +2560,96 @@ class TestSkipCoverage:
             patch("commit_check.engine.get_commit_info", return_value="Ada Lovelace"),
         ):
             assert validator.validate(context) == ValidationResult.FAIL
+
+
+class TestImperativeMorphology:
+    """The rule decides on form, not on vocabulary. See #526.
+
+    A word list can only approximate "is this an English imperative", and the
+    cost of every gap falls on someone who wrote the subject correctly. These
+    pin the three things that replace it: inflected first words are rejected,
+    everything else is not, and the few words whose spelling trips the test
+    are named rather than guessed at.
+    """
+
+    def _verdict(self, subject):
+        validator = SubjectImperativeValidator(
+            ValidationRule(check="subject_imperative")
+        )
+        return validator.validate(ValidationContext(stdin_text=subject))
+
+    @pytest.mark.benchmark
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "fix: fixed the parser",  # past tense
+            "fix: updated the docs",
+            "fix: removed the flag",
+            "feat: adding a retry",  # gerund
+            "feat: implementing the cache",
+            "fix: fixes the parser",  # third person
+            "fix: removes the flag",
+            "docs: documents the API",
+        ],
+    )
+    def test_inflected_first_words_are_rejected(self, subject):
+        """The failure the rule exists for, and now the only one it reports."""
+        assert self._verdict(subject) == ValidationResult.FAIL
+
+    @pytest.mark.benchmark
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            # Correct imperatives that no list contained, or ever would.
+            "feat: settle the report format",
+            "refactor: inline the helper",
+            "chore: retire the legacy path",
+            "fix: tighten the guard",
+            "fix: treat an absent value as missing",
+            # Adverb-led subjects. Correct imperative English that a list of
+            # *verbs* cannot represent without becoming a list of not-verbs.
+            "fix: always quote the path",
+            "feat: optionally skip the hook",
+            "fix: explicitly close the handle",
+            # British spelling, which is not a mistake.
+            "refactor: normalise the path separators",
+        ],
+    )
+    def test_uninflected_first_words_pass_without_being_listed(self, subject):
+        assert self._verdict(subject) == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "fix: embed the token",  # -ed, not a past tense
+            "fix: need a newer pip",
+            "fix: proceed without the cache",
+            "chore: spread the load",
+            "feat: bring back the flag",  # -ing, not a gerund
+            "fix: string the parts together",
+            "fix: ping the endpoint",
+            "fix: address the warning",  # -ss, not third person
+            "fix: process the queue",
+            "fix: guess the encoding",
+            "fix: focus the search",  # -s, not third person
+        ],
+    )
+    def test_lookalikes_are_not_mistaken_for_inflection(self, subject):
+        """The words a suffix rule gets wrong, enumerated rather than guessed."""
+        assert self._verdict(subject) == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    def test_a_noun_led_subject_now_passes(self):
+        """Documents the deliberate loosening, so a change to it is a choice.
+
+        The old list rejected this by accident of vocabulary, not because it
+        detected the mood. Naming it here means anyone tightening it later
+        does so on purpose.
+        """
+        assert self._verdict("fix: parser improvements") == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    def test_merge_and_fixup_subjects_still_bypass_the_rule(self):
+        assert self._verdict("Merge branch 'main' into topic") == ValidationResult.PASS
+        assert self._verdict("fixup! fixed the parser") == ValidationResult.PASS

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2601,14 +2601,13 @@ class TestImperativeMorphology:
         "subject",
         [
             # Correct imperatives that no list contained, or ever would.
-            "feat: settle the report format",
-            "refactor: inline the helper",
-            "chore: retire the legacy path",
-            "fix: tighten the guard",
-            "fix: treat an absent value as missing",
-            # Adverb-led subjects. Correct imperative English that a list of
-            # *verbs* cannot represent without becoming a list of not-verbs.
-            "fix: always quote the path",
+            "feat: reword the report format",
+            "refactor: dedupe the helper",
+            "chore: decommission the legacy path",
+            "fix: loosen the guard",
+            "fix: backfill an absent value",
+            # Adverb-led subjects, which a list of *verbs* cannot represent
+            # without becoming a list of not-verbs.
             "feat: optionally skip the hook",
             "fix: explicitly close the handle",
             # British spelling, which is not a mistake.
@@ -2629,14 +2628,28 @@ class TestImperativeMorphology:
             "feat: bring back the flag",  # -ing, not a gerund
             "fix: string the parts together",
             "fix: ping the endpoint",
-            "fix: address the warning",  # -ss, not third person
-            "fix: process the queue",
-            "fix: guess the encoding",
-            "fix: focus the search",  # -s, not third person
         ],
     )
     def test_lookalikes_are_not_mistaken_for_inflection(self, subject):
         """The words a suffix rule gets wrong, enumerated rather than guessed."""
+        assert self._verdict(subject) == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "fix: address the warning",  # -ss, never third person
+            "fix: process the queue",
+            "fix: guess the encoding",
+            "fix: focus the search",  # -s, but the stem is not a verb
+            "fix: status report is empty",  # noun-led
+            "chore: deps bump",
+            "fix: always quote the path",  # adverb-led
+            "fix: sometimes the cache is stale",
+        ],
+    )
+    def test_single_s_words_are_not_assumed_third_person(self, subject):
+        """A trailing -s only counts when the stem is a verb we know."""
         assert self._verdict(subject) == ValidationResult.PASS
 
     @pytest.mark.benchmark

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2590,6 +2590,8 @@ class TestImperativeMorphology:
             "fix: fixes the parser",  # third person
             "fix: removes the flag",
             "docs: documents the API",
+            "fix: tries the fallback",  # -ies, so the stem is "try"
+            "fix: applies the patch",
         ],
     )
     def test_inflected_first_words_are_rejected(self, subject):

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2630,6 +2630,9 @@ class TestImperativeMorphology:
             "feat: bring back the flag",  # -ing, not a gerund
             "fix: string the parts together",
             "fix: ping the endpoint",
+            "chore: weed out the dead code",
+            "fix: heed the configured timeout",
+            "feat: sling the payload over the wire",
         ],
     )
     def test_lookalikes_are_not_mistaken_for_inflection(self, subject):
@@ -2646,6 +2649,9 @@ class TestImperativeMorphology:
             "fix: focus the search",  # -s, but the stem is not a verb
             "fix: status report is empty",  # noun-led
             "chore: deps bump",
+            # Stems that are not verbs at all, so their plurals are nouns.
+            "fix: partials are rendered twice",
+            "chore: setups differ between CI and local",
             "fix: always quote the path",  # adverb-led
             "fix: sometimes the cache is stale",
         ],


### PR DESCRIPTION
Closes #526.

## Why the list could not work

CC003 asked whether the subject's first word appeared in a set of known imperative verbs. Imperative mood is a property of a word's **form**, not of its membership in a vocabulary — so the list was an approximation that rejected correct subjects wherever it fell short, and it always fell short.

#527 grew it from 396 to 529 words. That helped and did not fix it: each release recognises a few more verbs and the next contributor finds the next gap. It happened again in this session — `fix: treat a skipped run as non-failing` was rejected because `treat` had been added one release *later*.

## The change

The rule now asks the opposite question: is the first word in a form that is **not** imperative?

- past tense — `fixed`, `updated`, `removed`
- gerund — `adding`, `implementing`
- third-person singular — `fixes`, `removes`

That is also the only failure this rule was ever meant to catch, so a rejection now means the author really did write `fixed`.

`-s` is treated differently from the other two, because it is weaker evidence: plural nouns wear one too. It asks for corroboration — strip `-s`/`-es`/`-ies` and the stem has to be a verb already in `IMPERATIVES`. So `fixes → fix` still fails while `status` passes. Without that, `fix: status report` was rejected (caught in review).

## Measured

59,140 non-merge subjects from `git.git`, a project that writes strictly imperative subjects:

| rule | rejected |
|---|---|
| allow list (529 words, `main`) | 26,924 (45.5%) |
| morphology, without corroboration | 1,751 (2.96%) |
| **this branch** | **574 (0.97%)** |

The ~1,175 the corroboration recovers are nouns: `refs`×283, `ls`×189, `vcs`×111, `docs`×57, `files`×30, `status`×14. What still fails is mostly right — `added`, `fixed`, `updated`, `removed`, `fixes`.

**Known limit, stated rather than hidden:** the residue still contains `untracked`×26, `packed`×17, `spelling`×14, `detached`×12 — participles and gerund-nouns leading a noun phrase ("spelling in the docs"). Morphology cannot separate those from real inflections without a dictionary, and `main` rejects them too, so it is a pre-existing limit and not a regression. `notes` and `tests` are read as verbs for the same reason.

## What happens to `IMPERATIVES`

It is no longer an allow-list, and nothing passes or fails by being in it. The `first_word in IMPERATIVES` fast path turned out to guard exactly four words — `embed`, `feed`, `ping`, `speed` — all of which are already in `NON_IMPERATIVE_LOOKALIKES`, so it decided nothing. Removed, and verified across the 2,333 distinct first words in `git.git`: **zero verdict differences**.

What the set is still needed for is the stem test behind the `-s` rule. Dropping it entirely would mean no `-s` detection at all, costing `fixes`, `updates` and `checks` — the exact examples CC003's own error text and the docs name. So it stays, in a smaller job.

That change of job has a consequence found in review: an entry that is **not a verb** now turns its plural into a false rejection. `partial`, `setup` and `auto` were making `partials`, `setups` and `autos` read as third-person verbs, and have been removed. `init`, `polyfill` and `abstract` were checked and kept — those are verbs people write.

The practical consequence, and the one #526 was really about: **there is nothing to keep up with any more.** A verb missing from the set now costs a missed violation, never a false rejection, so nobody needs to send a patch adding the verb they just used. The file header said the opposite; it has been rewritten.

`NON_IMPERATIVE_LOOKALIKES` (new, 31 words) is the one set that still wants care, and only for words *ending* in `-ed` or `-ing` without being one. Both families are enumerated completely rather than sampled — a half-listed closed set would rebuild the same treadmill in miniature.

## The deliberate loosening

A noun-led subject such as `fix: parser improvements` now **passes**, where the list rejected it — by accident of vocabulary, not by detecting the mood. `test_a_noun_led_subject_now_passes` names that case so anyone tightening it later does so on purpose.

Behaviour changes in the loosening direction only: subjects that used to fail now pass, so no one's build breaks on upgrade.

## Note on the `.pre-commit-config.yaml` change

It is not unrelated, despite looking it. This PR adds `sting` to `NON_IMPERATIVE_LOOKALIKES`, and codespell reads that as a typo for `string` — `build` fails without the exclusion. The `iterm` entry was already there; the line is only re-quoted because an unquoted comma in a YAML flow sequence splits `iterm,sting` into two arguments, which is why the first attempt at the exclusion silently did nothing.

## Verification

- `564 passed`, ruff clean and formatted, `pre-commit run --all-files` clean.
- Tests in `TestImperativeMorphology`; **reverting the rule turns 10 red**, reverting just the `-s` corroboration turns 5 red — both checked by restoring the old code.
- The fast-path removal is proven behaviour-preserving on the corpus rather than argued.
- One pre-existing failure is unrelated and untouched: `config_test.py::test_load_config_file_permission_error` fails on a clean `main` in this environment too, because the suite runs as root and a permission-denied path cannot be provoked.

## Docs

None needed — [commit-check.com](https://commit-check.com/rules/#cc003) already described CC003 as checking for *"`fix`, not `fixed`, `fixes`, or `fixing`"*. The documentation was describing this behaviour all along; the implementation just didn't match it.

Per #526 this probably wants a minor version and a changelog note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn