### PR TITLE
docs: pin the README to v2.15.0, and make that a standing check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
 
 ## Keep the README pinned to the released version
 
-**Do this on every change, whatever you came here to do.** It is not a release-time task — the README's pre-commit snippets are the first thing a new user copies, 
+**Do this on every change, whatever you came here to do.** It is not a release-time task — the README's pre-commit snippets are the first thing a new user copies,
 and a stale pin is invisible: the snippet keeps working, it just installs an older release than the README describes.
 
 1. **Find the latest released version.**
@@ -36,7 +36,7 @@ and a stale pin is invisible: the snippet keeps working, it just installs an old
 
 The one exception is a pull request that prepares an unpublished release: there the pins are written **ahead** of the tag, on purpose, and the release is published before the pull request merges.
 
-`.pre-commit-config.yaml` is a different case and is **not** covered by this rule. That pin is this repository running its own hooks, 
+`.pre-commit-config.yaml` is a different case and is **not** covered by this rule. That pin is this repository running its own hooks,
 and pre-commit resolves it against real tags when CI runs — so pointing it at a version that is not published yet breaks the build. Bump it only after the release exists.
 
 ## Git Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
 
 ## Keep the README pinned to the released version
 
-**Do this on every change, whatever you came here to do.** It is not a release-time task — the README's pre-commit snippets are the first thing a new user copies, and a stale pin is invisible: the snippet keeps working, it just installs an older release than the README describes. Nothing in the test suite reads these pins, so only this check catches them. They had fallen three releases behind before anyone noticed.
+**Do this on every change, whatever you came here to do.** It is not a release-time task — the README's pre-commit snippets are the first thing a new user copies, 
+and a stale pin is invisible: the snippet keeps working, it just installs an older release than the README describes.
 
 1. **Find the latest released version.**
 
@@ -16,11 +17,14 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
    curl -s https://pypi.org/pypi/commit-check/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
    ```
 
-   The [releases page](https://github.com/commit-check/commit-check/releases) answers the same question, provided you read only **published** releases. A draft is not one, and you cannot tell by looking for a tag: a draft can be saved against a tag that already exists, and publishing to PyPI is a separate step from publishing the GitHub release. Read the published release, or ask PyPI as above.
+   The [releases page](https://github.com/commit-check/commit-check/releases) answers the same question, provided you read only **published** releases.
+   A draft is not one, and you cannot tell by looking for a tag: a draft can be saved against a tag that already exists, and publishing to PyPI is
+   a separate step from publishing the GitHub release. Read the published release, or ask PyPI as above.
 
-   Both have to be true before a version can be pinned: the **tag** must exist, because that is what pre-commit resolves `rev:` against, and **PyPI** must have the version, because that is what installs.
+   Both have to be true before a version can be pinned: the **tag** must exist, because that is what pre-commit resolves `rev:` against,
+   and **PyPI** must have the version, because that is what installs.
 
-2. **Check every pin in the README.**
+3. **Check every pin in the README.**
 
    ```bash
    grep -n "rev: v" README.md
@@ -28,11 +32,12 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
 
    Each one must name that version. Update any that do not, in the same pull request — do not open a follow-up issue for it.
 
-3. **Say so in the pull request description** when you moved them, so the bump is not a silent diff in an unrelated change.
+4. **Say so in the pull request description** when you moved them, so the bump is not a silent diff in an unrelated change.
 
 The one exception is a pull request that prepares an unpublished release: there the pins are written **ahead** of the tag, on purpose, and the release is published before the pull request merges.
 
-`.pre-commit-config.yaml` is a different case and is **not** covered by this rule. That pin is this repository running its own hooks, and pre-commit resolves it against real tags when CI runs — so pointing it at a version that is not published yet breaks the build. Bump it only after the release exists.
+`.pre-commit-config.yaml` is a different case and is **not** covered by this rule. That pin is this repository running its own hooks, 
+and pre-commit resolves it against real tags when CI runs — so pointing it at a version that is not published yet breaks the build. Bump it only after the release exists.
 
 ## Git Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,18 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
 
 1. **Find the latest released version.**
 
-   ```console
-   $ curl -s https://pypi.org/pypi/commit-check/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+   ```bash
+   curl -s https://pypi.org/pypi/commit-check/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
    ```
 
-   The [releases page](https://github.com/commit-check/commit-check/releases) answers the same question. A **draft** release is not released — it has no tag and no package, so it is not the answer here.
+   The [releases page](https://github.com/commit-check/commit-check/releases) answers the same question, provided you read only **published** releases. A draft is not one, and you cannot tell by looking for a tag: a draft can be saved against a tag that already exists, and publishing to PyPI is a separate step from publishing the GitHub release. Read the published release, or ask PyPI as above.
+
+   Both have to be true before a version can be pinned: the **tag** must exist, because that is what pre-commit resolves `rev:` against, and **PyPI** must have the version, because that is what installs.
 
 2. **Check every pin in the README.**
 
-   ```console
-   $ grep -n "rev: v" README.md
+   ```bash
+   grep -n "rev: v" README.md
    ```
 
    Each one must name that version. Update any that do not, in the same pull request — do not open a follow-up issue for it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ and a stale pin is invisible: the snippet keeps working, it just installs an old
    Both have to be true before a version can be pinned: the **tag** must exist, because that is what pre-commit resolves `rev:` against,
    and **PyPI** must have the version, because that is what installs.
 
-3. **Check every pin in the README.**
+2. **Check every pin in the README.**
 
    ```bash
    grep -n "rev: v" README.md
@@ -32,7 +32,7 @@ and a stale pin is invisible: the snippet keeps working, it just installs an old
 
    Each one must name that version. Update any that do not, in the same pull request — do not open a follow-up issue for it.
 
-4. **Say so in the pull request description** when you moved them, so the bump is not a silent diff in an unrelated change.
+3. **Say so in the pull request description** when you moved them, so the bump is not a silent diff in an unrelated change.
 
 The one exception is a pull request that prepares an unpublished release: there the pins are written **ahead** of the tag, on purpose, and the release is published before the pull request merges.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,32 @@ This file provides working guidelines for AI coding agents (e.g., GitHub Copilot
 
 - All changes must be submitted to the `main` branch **via a pull request**. Never push commits directly to `main`.
 
+## Keep the README pinned to the released version
+
+**Do this on every change, whatever you came here to do.** It is not a release-time task — the README's pre-commit snippets are the first thing a new user copies, and a stale pin is invisible: the snippet keeps working, it just installs an older release than the README describes. Nothing in the test suite reads these pins, so only this check catches them. They had fallen three releases behind before anyone noticed.
+
+1. **Find the latest released version.**
+
+   ```console
+   $ curl -s https://pypi.org/pypi/commit-check/json | python -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+   ```
+
+   The [releases page](https://github.com/commit-check/commit-check/releases) answers the same question. A **draft** release is not released — it has no tag and no package, so it is not the answer here.
+
+2. **Check every pin in the README.**
+
+   ```console
+   $ grep -n "rev: v" README.md
+   ```
+
+   Each one must name that version. Update any that do not, in the same pull request — do not open a follow-up issue for it.
+
+3. **Say so in the pull request description** when you moved them, so the bump is not a silent diff in an unrelated change.
+
+The one exception is a pull request that prepares an unpublished release: there the pins are written **ahead** of the tag, on purpose, and the release is published before the pull request merges.
+
+`.pre-commit-config.yaml` is a different case and is **not** covered by this rule. That pin is this repository running its own hooks, and pre-commit resolves it against real tags when CI runs — so pointing it at a version that is not published yet breaks the build. Bump it only after the release exists.
+
 ## Git Rules
 
 - **Follow the Conventional Branch spec** for branch names: `<type>/<description>` with lowercase kebab-case descriptions. Allowed types: `feature/`, `bugfix/`, `hotfix/`, `release/`, `chore/`. Example: `chore/add-agent-guidelines`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ commit-check --message --branch
 ```yaml
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.12.2
+    rev: v2.15.0
     hooks:
       - id: check-message
       - id: check-branch
@@ -196,7 +196,7 @@ commit-check --message
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.12.2
+    rev: v2.15.0
     hooks:
       - id: check-message
         args:
@@ -226,7 +226,7 @@ commit-check --no-force-push
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.12.2
+    rev: v2.15.0
     hooks:
       - id: check-no-force-push
         stages: [pre-push]


### PR DESCRIPTION
Release preparation for v2.15.0, plus the rule that should have caught the drift.

## The README was three releases behind

All three pre-commit snippets named `v2.12.2` — 2.13.0, 2.13.4 and 2.14.0 had shipped since. They are the first thing a new user copies, and the staleness is invisible: the snippet keeps working, it just installs an older release than the page around it describes. Nothing in the test suite reads these pins, which is how they drifted that far without anything going red.

All three now name **v2.15.0**, the release being prepared. That is deliberately ahead of the tag — publish first, then merge.

## The standing rule

`AGENTS.md` gains the check as a rule that applies to **every** change, not just release preparation: look up the released version, compare it against every `rev:` in the README, and fix any that disagree in the same pull request.

Two things it records because they are easy to get wrong:

- **A draft release is not released** — no tag, no package, so it is not the answer to "what is the latest version".
- **`.pre-commit-config.yaml` is deliberately excluded.** That pin is this repository running its own hooks, and pre-commit resolves it against real tags when CI runs, so pointing it at an unpublished version breaks the build. It currently sits at `v2.11.0` and can be bumped once v2.15.0 exists — I have left it alone here rather than break the build to fix a cosmetic lag.

## Checks

Documentation and guidelines only; no code, no test changes. The README diff is three `rev:` lines.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all pre-commit configuration examples to use `commit-check` release `v2.15.0`.
  * Added guidance to keep documented version references current and disclose updates.
  * Clarified version handling for unreleased preparations and published configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->