### PR TITLE
test: stop four JSON tests taking their verdict from the checkout

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -35,6 +35,26 @@ def _stdin_gate_open(request, monkeypatch):
     yield
 
 
+@pytest.fixture
+def pinned_author(mocker):
+    """Pin the identity the engine resolves, so no verdict comes from the checkout.
+
+    A message given on stdin or in a file describes a *prospective* commit, so
+    ``_resolve_current_author`` reads ``git config user.name`` and falls back to
+    the author of ``HEAD``. Both are ambient. A CI runner configures no identity,
+    so the fallback always wins there, and when ``HEAD`` happens to be a bot's
+    commit that name is in ``ignore_authors`` — every commit check skips, and a
+    test asserting ``pass`` sees ``skip`` instead.
+
+    That is not hypothetical: it turned ``main`` red the moment a dependabot
+    merge landed, having passed on every pull request before it. Any test that
+    supplies a message and asserts a verdict needs this, or it is really
+    asserting something about whoever committed last.
+    """
+    mocker.patch("commit_check.engine.get_git_config_value", return_value="test-author")
+    mocker.patch("commit_check.engine.get_commit_info", return_value="test-author")
+
+
 class TestMain:
     @pytest.mark.benchmark
     def test_help(self, capfd, monkeypatch):
@@ -693,7 +713,9 @@ class TestJsonFormat:
     """Tests for --format json machine-readable output."""
 
     @pytest.mark.benchmark
-    def test_json_format_valid_message_returns_pass(self, mocker, capsys, monkeypatch):
+    def test_json_format_valid_message_returns_pass(
+        self, mocker, capsys, monkeypatch, pinned_author
+    ):
         """JSON output for a valid commit message has status=pass."""
         mocker.patch("sys.stdin.isatty", return_value=False)
         mocker.patch("sys.stdin.read", return_value="feat: add new feature\n")
@@ -709,7 +731,9 @@ class TestJsonFormat:
         assert all("check" in c and "status" in c for c in data["checks"])
 
     @pytest.mark.benchmark
-    def test_json_format_pass_reports_checked_value(self, mocker, capsys, monkeypatch):
+    def test_json_format_pass_reports_checked_value(
+        self, mocker, capsys, monkeypatch, pinned_author
+    ):
         """JSON output reports the checked value even when the check passed."""
         mocker.patch("sys.stdin.isatty", return_value=False)
         mocker.patch("sys.stdin.read", return_value="feat: add new feature\n")
@@ -765,7 +789,7 @@ class TestJsonFormat:
         assert "\033[" not in out
 
     @pytest.mark.benchmark
-    def test_json_format_from_file(self, capsys, monkeypatch):
+    def test_json_format_from_file(self, capsys, monkeypatch, pinned_author):
         """JSON mode works when reading commit message from a file."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
             f.write("fix: resolve null pointer in auth module")
@@ -782,7 +806,9 @@ class TestJsonFormat:
             os.unlink(tmp_path)
 
     @pytest.mark.benchmark
-    def test_json_format_exit_code_matches_status(self, mocker, capsys, monkeypatch):
+    def test_json_format_exit_code_matches_status(
+        self, mocker, capsys, monkeypatch, pinned_author
+    ):
         """Exit code 1 when JSON status is fail, exit code 0 when pass."""
         # --- pass case ---
         mocker.patch("sys.stdin.isatty", return_value=False)
@@ -802,6 +828,36 @@ class TestJsonFormat:
         out, _ = capsys.readouterr()
         assert rc_fail == 1
         assert json.loads(out)["status"] == "fail"
+
+    @pytest.mark.benchmark
+    def test_json_format_skips_when_head_author_is_ignored(
+        self, mocker, capsys, monkeypatch
+    ):
+        """An unconfigured identity falls back to HEAD's author, ignore list and all.
+
+        The counterpart to ``pinned_author``: rather than let this behaviour
+        stay ambient — where it silently decides other tests' verdicts — it is
+        asserted here. With no ``user.name`` configured, as on a CI runner, the
+        author of ``HEAD`` decides, so a bot's merge commit skips every check
+        even though the message under test is a perfectly valid one.
+
+        Exit code stays 0: a skip is not a failure.
+        """
+        mocker.patch("commit_check.engine.get_git_config_value", return_value="")
+        mocker.patch(
+            "commit_check.engine.get_commit_info", return_value="dependabot[bot]"
+        )
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add new feature\n")
+
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--format", "json"])
+        rc = main()
+
+        out, _ = capsys.readouterr()
+        data = json.loads(out)
+        assert rc == 0
+        assert data["status"] == "skip"
+        assert all(c["status"] == "skip" for c in data["checks"])
 
 
 class TestNoBanner:


### PR DESCRIPTION
Fixes the four `TestJsonFormat` failures on [the push run for #542](https://github.com/commit-check/commit-check/actions/runs/31673521767/job/94363462062), all reading `skip` where they assert `pass`.

## Nothing regressed — the tests were measuring the repository they run in

Each of the four supplies a message (on stdin or in a file), which makes it a **prospective** commit. `_resolve_current_author` then does:

```python
if context.stdin_text is not None or context.commit_file is not None:
    return get_git_config_value("user.name") or get_commit_info("an")
```

Both sources are ambient. A GitHub runner configures no git identity — no workflow in this repository sets one — so the fallback always decides, and #542 was a dependabot merge: `HEAD`'s author was `dependabot[bot]`, which `cchk.toml` lists in `[commit] ignore_authors`. Every commit check skipped, and overall status is `skip` when they all do.

## Reproduced

A clone pinned to `9f12a63` with the global and system git config disabled, which is what the runner looks like:

```
HEAD author : dependabot[bot]
user.name   : ''        ->  status: skip     (the four failures, exactly)
user.name   : set       ->  status: pass     (why laptops and PR runs were green)
```

So this was never about #542's contents, and **it will recur on the next bot-authored merge to `main`** — dependabot, pre-commit-ci, copilot or coderabbitai.

## The fix

The four tests take a new `pinned_author` fixture that fixes both identity sources, so the verdict comes from the message under test. Worth noting: the two tests in the class that kept passing are exactly the two that already patched `get_commit_info` for unrelated reasons — the same pin, arrived at by accident.

A fixture that pins this would also hide the fallback everywhere it applies, so the behaviour is now asserted directly rather than left ambient: a new test drives an unconfigured identity with a bot as `HEAD`'s author and expects every check to skip, exit code still `0`. What silently decided other tests' results is now a contract of its own.

## Checks

In the reproduction clone: **4 failed before, 7 passed after**. Full suite unchanged in both a configured and an unconfigured environment (`581 passed`; the one unrelated failure, `test_load_config_file_permission_error`, fails only because my sandbox runs as root, where `chmod 000` does not deny access — it fails identically on unmodified `main` and passes in CI).

## Not changed

Whether the fallback *should* apply to `ignore_authors` for a prospective message is a separate design question — the author of the previous commit is arguably irrelevant to a message not yet written. Changing it would alter real behaviour (a bot's PR checked with `-m` on a runner with no git identity would stop being exempt), so this PR only stops the tests depending on it and leaves the call to you.


---
_Generated by [Claude Code](https://claude.ai/code/session_01U9zFxq8V4qxG4aMzJhGBFn)_