### PR TITLE
docs: Clean up README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ local hooks, CI, GitHub Actions, and AI automation.
 - **Machine-readable output:** JSON + Python API for automation and AI agents
 
 ![commit-check demo](https://github.com/commit-check/commit-check/raw/main/assets/demo.gif)
-
 <br>
 
 ## Quick Start


### PR DESCRIPTION
Removed extra line break before 'Quick Start' section.