### PR TITLE
feat: add tag name validation (CC401)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,3 +35,12 @@
   pass_filenames: false
   always_run: true
   language: python
+- id: check-tag
+  name: check tag name
+  description: ensures pushed tag names match regex
+  entry: commit-check
+  args: [--tag]
+  stages: [pre-push]
+  pass_filenames: false
+  always_run: true
+  language: python

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ repos:
         stages: [pre-push]
 ```
 
+> [!NOTE]
+> The `check-tag` hook ships in the first release after v2.15.1 — bump `rev`
+> to that release once it is published.
+
 ## AI-Native Usage
 
 Commit Check is designed to be consumed by AI agents, LLM toolchains, and

--- a/README.md
+++ b/README.md
@@ -236,6 +236,33 @@ repos:
 > push has already been started, and standard `git push` output does not carry
 > the pre-push ref metadata that `commit-check` uses.
 
+### Check Tag Names
+
+Use `--tag` to validate the name of every tag pointing at `HEAD` (or at
+`--rev`). The default pattern accepts SemVer with an optional leading `v`
+(`v1.2.3` or `1.2.3`, pre-release and build suffixes included); set
+`regex` in the `[tag]` config section or pass `--tag-regex` to change it.
+A commit with no tag is reported as skipped, not failed.
+
+```bash
+# Validate the tag(s) at HEAD, e.g. in a CI job triggered by a tag push
+commit-check --tag
+
+# Enforce a custom scheme
+commit-check --tag --tag-regex '^v\d+\.\d+\.\d+$'
+```
+
+```yaml
+# In pre-commit hooks (.pre-commit-config.yaml): validates the tag names
+# a push carries, from the pre-push ref metadata on stdin
+repos:
+  - repo: https://github.com/commit-check/commit-check
+    rev: v2.15.1
+    hooks:
+      - id: check-tag
+        stages: [pre-push]
+```
+
 ## AI-Native Usage
 
 Commit Check is designed to be consumed by AI agents, LLM toolchains, and
@@ -557,6 +584,7 @@ reflects a DIY approach rather than built-in product features.
 |---------|-------------|------------|------|-----------------|-------------|
 | Conventional Commits enforcement | ✅ | ✅ | Partial | Partial[^4] | DIY |
 | Branch naming validation | ✅ | ❌ | ✅ | ✅[^4] | DIY |
+| Tag naming validation | ✅ | ❌ | ❌ | ✅[^4] | DIY |
 | Force push blocking | ✅ | ❌ | ❌ | ✅ | DIY |
 | Author name / email validation | ✅ | ❌ | ✅ | ✅[^4] | DIY |
 | Signed-off-by trailer enforcement | ✅ | Partial[^1] | ❌ | ❌ | DIY |

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -97,8 +97,13 @@ DEFAULT_BRANCH_NAMES: list[str] = []
 
 # Tag naming default: SemVer, with an optional leading "v" (v1.2.3 or 1.2.3),
 # allowing pre-release and build-metadata suffixes (v1.2.3-rc.1+build.5).
+# The body is the official semver.org pattern, which also rejects leading
+# zeroes in version-core numbers and numeric pre-release identifiers.
 DEFAULT_TAG_REGEX = (
-    r"^v?\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.\-]*)?(\+[0-9A-Za-z][0-9A-Za-z.\-]*)?$"
+    r"^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?"
+    r"(?:\+[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)?$"
 )
 
 # Push-related defaults

--- a/commit_check/__init__.py
+++ b/commit_check/__init__.py
@@ -95,6 +95,12 @@ DEFAULT_BRANCH_TYPES = [
 # Additional allowed branch names (e.g., develop, staging)
 DEFAULT_BRANCH_NAMES: list[str] = []
 
+# Tag naming default: SemVer, with an optional leading "v" (v1.2.3 or 1.2.3),
+# allowing pre-release and build-metadata suffixes (v1.2.3-rc.1+build.5).
+DEFAULT_TAG_REGEX = (
+    r"^v?\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.\-]*)?(\+[0-9A-Za-z][0-9A-Za-z.\-]*)?$"
+)
+
 # Push-related defaults
 DEFAULT_PUSH_RULES = {
     "allow_force_push": True,

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -7,7 +7,7 @@ forward to an LLM.
 
 Typical usage::
 
-    from commit_check.api import validate_message, validate_branch, validate_author
+    from commit_check.api import validate_message, validate_branch, validate_tag, validate_author
 
     result = validate_message("feat: add streaming support")
     if result["status"] == "fail":
@@ -173,6 +173,39 @@ def validate_branch(
         config=cfg,
     )
     return _run_checks(["branch", "merge_base"], context, cfg)
+
+
+def validate_tag(
+    tag: str | None = None,
+    *,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Validate a tag name.
+
+    :param tag: Tag name to validate. Multiple tags can be passed one per
+        line. If *None*, the tags pointing at ``HEAD`` are used (via
+        ``git tag --points-at``); a commit with no tag reports ``"skip"``.
+    :param config: Optional configuration override dict. The pattern comes
+        from ``config["tag"]["regex"]`` and defaults to SemVer with an
+        optional leading ``v`` (``v1.2.3`` or ``1.2.3``).
+    :returns: A dict with ``"status"`` and ``"checks"``.
+
+    Example::
+
+        >>> from commit_check.api import validate_tag
+        >>> validate_tag("v1.2.3")["status"]
+        'pass'
+        >>> validate_tag("release-candidate")["status"]
+        'fail'
+    """
+    cfg = _merge_config(config)
+    # Pass the tag via stdin_text so TagValidator picks it up without calling
+    # git. When tag is None the validator will fall back to git itself.
+    context = ValidationContext(
+        stdin_text=tag.strip() if tag else None,
+        config=cfg,
+    )
+    return _run_checks(["tag"], context, cfg)
 
 
 def validate_push(

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -200,9 +200,11 @@ def validate_tag(
     """
     cfg = _merge_config(config)
     # Pass the tag via stdin_text so TagValidator picks it up without calling
-    # git. When tag is None the validator will fall back to git itself.
+    # git. Only None falls back to git: an explicit empty string names an
+    # empty tag list, which skips rather than reading HEAD behind the
+    # caller's back.
     context = ValidationContext(
-        stdin_text=tag.strip() if tag else None,
+        stdin_text=tag.strip() if tag is not None else None,
         config=cfg,
     )
     return _run_checks(["tag"], context, cfg)

--- a/commit_check/config_merger.py
+++ b/commit_check/config_merger.py
@@ -14,6 +14,7 @@ from commit_check import (
     DEFAULT_BOOLEAN_RULES,
     DEFAULT_PUSH_RULES,
     DEFAULT_AI_ATTRIBUTION,
+    DEFAULT_TAG_REGEX,
 )
 
 
@@ -91,6 +92,9 @@ def get_default_config() -> dict[str, Any]:
         "push": {
             "allow_force_push": DEFAULT_PUSH_RULES["allow_force_push"],
         },
+        "tag": {
+            "regex": DEFAULT_TAG_REGEX,
+        },
     }
 
 
@@ -135,6 +139,8 @@ class ConfigMerger:
         "CCHK_BRANCH_IGNORE_AUTHORS": ("branch", "ignore_authors", parse_list),
         # Push section
         "CCHK_ALLOW_FORCE_PUSH": ("push", "allow_force_push", parse_bool),
+        # Tag section
+        "CCHK_TAG_REGEX": ("tag", "regex", str),
     }
 
     # Mapping of CLI argument names to config keys
@@ -165,12 +171,14 @@ class ConfigMerger:
         "branch_ignore_authors": ("branch", "ignore_authors"),
         # Push section
         "allow_force_push": ("push", "allow_force_push"),
+        # Tag section
+        "tag_regex": ("tag", "regex"),
     }
 
     @staticmethod
     def parse_env_vars() -> dict[str, Any]:
         """Parse environment variables with CCHK_ prefix into config dict."""
-        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}}
+        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}, "tag": {}}
 
         for env_var, (section, key, parser) in ConfigMerger.ENV_VAR_MAPPING.items():
             value = os.environ.get(env_var)
@@ -189,7 +197,7 @@ class ConfigMerger:
     @staticmethod
     def parse_cli_args(args: argparse.Namespace) -> dict[str, Any]:
         """Parse CLI arguments into config dict."""
-        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}}
+        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}, "tag": {}}
 
         for arg_name, (section, key) in ConfigMerger.CLI_ARG_MAPPING.items():
             if hasattr(args, arg_name):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -18,6 +18,7 @@ from commit_check.util import (
     get_git_config_value,
     get_branch_name,
     get_git_remotes,
+    get_tags_at,
     get_upstream_branch,
     get_upstream_remote_sha,
     has_commits,
@@ -606,6 +607,67 @@ class BranchValidator(BaseValidator):
         return ValidationResult.FAIL
 
 
+class TagValidator(BaseValidator):
+    """Validates tag names.
+
+    Checks every tag pointing at the revision under test (``--rev``, or
+    ``HEAD``). A commit with no tag is a skip, not a failure: the rule
+    validates how tags are named, and the absence of one is not a naming
+    violation. Piped input (or an API-supplied value) names the tags to check
+    directly, one per line, without consulting git.
+    """
+
+    @staticmethod
+    def _tags_from_stdin(text: str) -> list[str]:
+        """Extract tag names from piped input.
+
+        Two shapes arrive here: bare tag names (API callers, ``echo v1 |``),
+        and the four-field ``<local ref> <sha> <remote ref> <sha>`` lines a
+        pre-push hook receives. For push lines the tags under push are the
+        ``refs/tags/*`` refs — a push carrying no tag ref yields nothing to
+        validate, and a deletion (all-zero local sha) removes a tag rather
+        than naming a new one, so neither can fail the check.
+        """
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        push_lines = [ln for ln in lines if len(ln.split()) == 4 and "refs/" in ln]
+        if push_lines and len(push_lines) == len(lines):
+            tags = []
+            for ln in push_lines:
+                local_ref, local_sha, remote_ref, _ = ln.split()
+                if set(local_sha) == {"0"}:
+                    continue
+                for ref in (local_ref, remote_ref):
+                    if ref.startswith("refs/tags/"):
+                        tags.append(ref.removeprefix("refs/tags/"))
+                        break
+            return list(dict.fromkeys(tags))
+        return lines
+
+    def validate(self, context: ValidationContext) -> ValidationResult:
+        if context.stdin_text is not None:
+            tags = self._tags_from_stdin(context.stdin_text)
+        else:
+            tags = get_tags_at(context.rev or "HEAD")
+
+        if not tags:
+            return ValidationResult.SKIP
+
+        self._checked_value = ", ".join(tags)
+
+        if not self.rule.regex:
+            return ValidationResult.PASS
+
+        import re
+
+        for tag in tags:
+            if not re.match(self.rule.regex, tag):
+                self._checked_value = tag
+                self._print_failure(tag)
+                return ValidationResult.FAIL
+
+        return ValidationResult.PASS
+
+
 class MergeBaseValidator(BaseValidator):
     """Validates merge base ancestry."""
 
@@ -1051,6 +1113,7 @@ class ValidationEngine:
         "ignore_authors": CommitTypeValidator,
         "no_force_push": ForcePushValidator,
         "ai_attribution": AiAttributionValidator,
+        "tag": TagValidator,
     }
 
     def __init__(self, rules: list[ValidationRule]):

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -169,6 +169,15 @@ def _get_parser() -> argparse.ArgumentParser:
     )
 
     check_group.add_argument(
+        "-t",
+        "--tag",
+        help="check the name of the tag(s) pointing at HEAD (or --rev); "
+        "a commit with no tag is reported as skipped",
+        action="store_true",
+        required=False,
+    )
+
+    check_group.add_argument(
         "-n",
         "--author-name",
         help="check git author name",
@@ -411,6 +420,20 @@ def _get_parser() -> argparse.ArgumentParser:
         help="comma-separated list of authors to ignore for branch checks",
     )
 
+    # Tag configuration options
+    tag_group = parser.add_argument_group(
+        "tag options", "Configuration options for --tag validation"
+    )
+
+    tag_group.add_argument(
+        "--tag-regex",
+        type=str,
+        default=None,
+        metavar="REGEX",
+        help="pattern tag names must match (default: SemVer with an optional "
+        "leading v, e.g. v1.2.3); an empty value disables the pattern match",
+    )
+
     return parser
 
 
@@ -437,7 +460,7 @@ def _resolve_stdin_for_non_message(
 ) -> str | None:
     """Resolve stdin content for non-message validation types."""
     has_non_message_check = any(
-        [args.branch, args.author_name, args.author_email, args.no_force_push]
+        [args.branch, args.tag, args.author_name, args.author_email, args.no_force_push]
     )
     if not has_non_message_check:
         return None
@@ -472,6 +495,8 @@ def _get_requested_checks(args: argparse.Namespace) -> list[str]:
         )
     if args.branch:
         requested_checks.extend(["branch", "merge_base"])
+    if args.tag:
+        requested_checks.append("tag")
     if args.author_name:
         requested_checks.append("author_name")
     if args.author_email:

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -129,11 +129,15 @@ class RuleBuilder:
         """
         rules = []
 
+        # Malformed config (a non-table [tag], a non-string regex) falls back
+        # to the defaults instead of surfacing as an AttributeError or a
+        # TypeError from re.match deep inside the validator.
+        tag_config = self.tag_config if isinstance(self.tag_config, dict) else {}
+
         for catalog_entry in TAG_RULES:
             if catalog_entry.check == "tag":
-                regex = self.tag_config.get("regex", DEFAULT_TAG_REGEX)
-                if isinstance(regex, str):
-                    regex = regex.strip()
+                regex = tag_config.get("regex", DEFAULT_TAG_REGEX)
+                regex = regex.strip() if isinstance(regex, str) else DEFAULT_TAG_REGEX
                 rules.append(
                     ValidationRule(
                         check=catalog_entry.check,

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -7,6 +7,7 @@ from commit_check.rules_catalog import (
     COMMIT_RULES,
     BRANCH_RULES,
     PUSH_RULES,
+    TAG_RULES,
     RULES_BY_CHECK,
     RuleCatalogEntry,
 )
@@ -17,6 +18,7 @@ from commit_check import (
     DEFAULT_BOOLEAN_RULES,
     DEFAULT_PUSH_RULES,
     DEFAULT_AI_ATTRIBUTION,
+    DEFAULT_TAG_REGEX,
 )
 
 
@@ -74,6 +76,7 @@ class RuleBuilder:
         self.commit_config = config.get("commit", {})
         self.branch_config = config.get("branch", {})
         self.push_config = config.get("push", {})
+        self.tag_config = config.get("tag", {})
 
     def build_all_rules(self) -> list[ValidationRule]:
         """Build all validation rules from config."""
@@ -81,6 +84,7 @@ class RuleBuilder:
         rules.extend(self._build_commit_rules())
         rules.extend(self._build_branch_rules())
         rules.extend(self._build_push_rules())
+        rules.extend(self._build_tag_rules())
         return rules
 
     def _build_commit_rules(self) -> list[ValidationRule]:
@@ -113,6 +117,31 @@ class RuleBuilder:
             rule = self._build_push_rule(catalog_entry)
             if rule:
                 rules.append(rule)
+
+        return rules
+
+    def _build_tag_rules(self) -> list[ValidationRule]:
+        """Build tag-related validation rules.
+
+        The tag rule is always built — like every check it only runs when
+        requested (``--tag``). An empty ``regex`` in the ``[tag]`` section
+        deliberately disables the pattern match.
+        """
+        rules = []
+
+        for catalog_entry in TAG_RULES:
+            if catalog_entry.check == "tag":
+                regex = self.tag_config.get("regex", DEFAULT_TAG_REGEX)
+                if isinstance(regex, str):
+                    regex = regex.strip()
+                rules.append(
+                    ValidationRule(
+                        check=catalog_entry.check,
+                        regex=regex or None,
+                        error=catalog_entry.error,
+                        suggest=catalog_entry.suggest,
+                    )
+                )
 
         return rules
 

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -11,6 +11,7 @@ ID ranges
 ``CC1xx``  Author (name / email) rules
 ``CC2xx``  Branch rules
 ``CC3xx``  Push rules
+``CC4xx``  Tag rules
 =========  ==================================
 
 Internal bookkeeping entries that never produce a diagnostic (such as
@@ -213,10 +214,21 @@ BRANCH_RULES = [
     ),
 ]
 
+# Tag rules
+TAG_RULES = [
+    RuleCatalogEntry(
+        rule_id="CC401",
+        check="tag",
+        regex=None,  # Provided by config, defaulting to SemVer with optional v
+        error="The tag name does not match the required pattern",
+        suggest="Use a SemVer tag like v1.2.3, or set a custom pattern via regex in the [tag] config section",
+    ),
+]
+
 #: All catalog entries that represent a user-facing, documented rule.
 ALL_RULES = [
     entry
-    for entry in (*COMMIT_RULES, *BRANCH_RULES, *PUSH_RULES)
+    for entry in (*COMMIT_RULES, *BRANCH_RULES, *PUSH_RULES, *TAG_RULES)
     if entry.rule_id is not None
 ]
 

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -80,18 +80,29 @@ def get_tags_at(rev: str = "HEAD") -> list[str]:
     :param rev: Revision whose tags to list, ``HEAD`` by default.
     :returns: Tag names pointing at the revision, oldest first. When the
         repository has none there but the run is a GitHub Actions tag build
-        (``GITHUB_REF_TYPE=tag``), the pushed tag name from ``GITHUB_REF_NAME``
-        stands in — a shallow or partial checkout may not carry the tag ref
-        even though the workflow was triggered by it.
+        (``GITHUB_REF_TYPE=tag``) checking that build's own revision, the
+        pushed tag name from ``GITHUB_REF_NAME`` stands in — a shallow or
+        partial checkout may not carry the tag ref even though the workflow
+        was triggered by it.
     """
-    try:
-        commands = ["git", "tag", "--points-at", rev]
-        output = cmd_output(commands)
-    except CalledProcessError:
-        output = ""
+    # Run git directly: cmd_output() returns stderr text on a nonzero exit,
+    # and a git diagnostic must not be parsed as a tag name.
+    result = subprocess.run(
+        ["git", "tag", "--points-at", rev],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    output = result.stdout if result.returncode == 0 else ""
 
     tags = [line.strip() for line in output.splitlines() if line.strip()]
-    if not tags and os.getenv("GITHUB_REF_TYPE") == "tag":
+    if (
+        not tags
+        and os.getenv("GITHUB_REF_TYPE") == "tag"
+        # Only the workflow's own revision may borrow the event's tag name:
+        # with --rev at another commit the pushed tag says nothing about it.
+        and rev in ("HEAD", os.getenv("GITHUB_SHA"))
+    ):
         ref_name = os.getenv("GITHUB_REF_NAME", "").strip()
         if ref_name:
             tags = [ref_name]

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -74,6 +74,30 @@ def get_branch_name() -> str:
     return branch_name.strip()
 
 
+def get_tags_at(rev: str = "HEAD") -> list[str]:
+    """List the tags pointing at a revision.
+
+    :param rev: Revision whose tags to list, ``HEAD`` by default.
+    :returns: Tag names pointing at the revision, oldest first. When the
+        repository has none there but the run is a GitHub Actions tag build
+        (``GITHUB_REF_TYPE=tag``), the pushed tag name from ``GITHUB_REF_NAME``
+        stands in — a shallow or partial checkout may not carry the tag ref
+        even though the workflow was triggered by it.
+    """
+    try:
+        commands = ["git", "tag", "--points-at", rev]
+        output = cmd_output(commands)
+    except CalledProcessError:
+        output = ""
+
+    tags = [line.strip() for line in output.splitlines() if line.strip()]
+    if not tags and os.getenv("GITHUB_REF_TYPE") == "tag":
+        ref_name = os.getenv("GITHUB_REF_NAME", "").strip()
+        if ref_name:
+            tags = [ref_name]
+    return tags
+
+
 def get_upstream_branch() -> str:
     """Return the configured upstream ref for the current branch.
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -514,3 +514,9 @@ class TestValidateTag:
         out, err = capfd.readouterr()
         assert out == ""
         assert err == ""
+
+    @pytest.mark.benchmark
+    def test_empty_string_skips_instead_of_reading_git(self):
+        """An explicit empty string names an empty tag list, not HEAD."""
+        result = validate_tag("")
+        assert result["status"] == "skip"

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from commit_check.api import (
     validate_message,
     validate_branch,
+    validate_tag,
     validate_author,
     validate_all,
     validate_push,
@@ -473,3 +474,43 @@ class TestSkippedStatus:
 
         assert result["status"] == "skip"
         assert {c["status"] for c in result["checks"]} == {"skip"}
+
+
+class TestValidateTag:
+    """Tests for validate_tag()."""
+
+    @pytest.mark.benchmark
+    def test_semver_tag_passes(self):
+        result = validate_tag("v1.2.3")
+        assert result["status"] == "pass"
+
+    @pytest.mark.benchmark
+    def test_bare_semver_tag_passes(self):
+        result = validate_tag("1.2.3")
+        assert result["status"] == "pass"
+
+    @pytest.mark.benchmark
+    def test_non_semver_tag_fails(self):
+        result = validate_tag("release-candidate")
+        assert result["status"] == "fail"
+        failed = [c for c in result["checks"] if c["status"] == "fail"]
+        assert failed[0]["rule_id"] == "CC401"
+
+    @pytest.mark.benchmark
+    def test_custom_pattern(self):
+        cfg = {"tag": {"regex": r"^rel-\d+$"}}
+        assert validate_tag("rel-7", config=cfg)["status"] == "pass"
+        assert validate_tag("v1.2.3", config=cfg)["status"] == "fail"
+
+    @pytest.mark.benchmark
+    def test_multiline_tags(self):
+        assert validate_tag("v1.0.0\nv1.0.1")["status"] == "pass"
+        assert validate_tag("v1.0.0\nbad_tag")["status"] == "fail"
+
+    @pytest.mark.benchmark
+    def test_no_output(self, capfd):
+        """validate_tag must not print anything."""
+        validate_tag("bad_tag_name")
+        out, err = capfd.readouterr()
+        assert out == ""
+        assert err == ""

--- a/tests/config_merger_test.py
+++ b/tests/config_merger_test.py
@@ -377,3 +377,23 @@ subject_max_length = 200
         args = argparse.Namespace()
         with pytest.raises(FileNotFoundError):
             ConfigMerger.from_all_sources(args, str(tmp_path / "nonexistent.toml"))
+
+
+class TestTagConfig:
+    """Tests for the [tag] section across config sources."""
+
+    @pytest.mark.benchmark
+    def test_default_config_has_tag_regex(self):
+        from commit_check import DEFAULT_TAG_REGEX
+        from commit_check.config_merger import get_default_config
+
+        config = get_default_config()
+        assert config["tag"]["regex"] == DEFAULT_TAG_REGEX
+
+    @pytest.mark.benchmark
+    def test_env_var_tag_regex(self, monkeypatch):
+        from commit_check.config_merger import ConfigMerger
+
+        monkeypatch.setenv("CCHK_TAG_REGEX", r"^rel-\d+$")
+        config = ConfigMerger.parse_env_vars()
+        assert config["tag"]["regex"] == r"^rel-\d+$"

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -12,6 +12,7 @@ from commit_check.engine import (
     ValidationEngine,
     CommitMessageValidator,
     BranchValidator,
+    TagValidator,
     AuthorValidator,
     CommitTypeValidator,
     SubjectImperativeValidator,
@@ -2761,3 +2762,125 @@ class TestImperativeMorphology:
         not judged, and SKIP keeps that distinct from having passed."""
         assert self._verdict("Merge branch 'main' into topic") == ValidationResult.SKIP
         assert self._verdict("fixup! fixed the parser") == ValidationResult.SKIP
+
+
+class TestTagValidator:
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_valid_tag(self, mock_get_tags_at):
+        """A tag matching the pattern passes."""
+        mock_get_tags_at.return_value = ["v1.2.3"]
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        result = validator.validate(ValidationContext())
+        assert result == ValidationResult.PASS
+        assert validator._checked_value == "v1.2.3"
+
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_invalid_tag(self, mock_get_tags_at):
+        """A tag violating the pattern fails."""
+        mock_get_tags_at.return_value = ["release-candidate"]
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        validator._suppress_output = True
+        result = validator.validate(ValidationContext())
+        assert result == ValidationResult.FAIL
+        assert validator._checked_value == "release-candidate"
+
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_no_tags_skips(self, mock_get_tags_at):
+        """A commit with no tag is a skip, not a failure."""
+        mock_get_tags_at.return_value = []
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        result = validator.validate(ValidationContext())
+        assert result == ValidationResult.SKIP
+
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_multiple_tags_one_bad_fails(self, mock_get_tags_at):
+        """Every tag pointing at the commit is validated."""
+        mock_get_tags_at.return_value = ["v1.2.3", "bad_tag"]
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        validator._suppress_output = True
+        result = validator.validate(ValidationContext())
+        assert result == ValidationResult.FAIL
+        assert validator._checked_value == "bad_tag"
+
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_uses_rev(self, mock_get_tags_at):
+        """--rev names the revision whose tags are read."""
+        mock_get_tags_at.return_value = ["v1.2.3"]
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        validator.validate(ValidationContext(rev="abc123"))
+        mock_get_tags_at.assert_called_once_with("abc123")
+
+    @pytest.mark.benchmark
+    def test_tag_validator_stdin_bypasses_git(self):
+        """Piped input names the tags directly, without consulting git."""
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        result = validator.validate(ValidationContext(stdin_text="v9.9.9"))
+        assert result == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    def test_tag_validator_stdin_multiline(self):
+        """Multiple piped tags are validated one per line."""
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        validator._suppress_output = True
+        result = validator.validate(ValidationContext(stdin_text="v1.0.0\nnope\n"))
+        assert result == ValidationResult.FAIL
+
+    @patch("commit_check.engine.get_tags_at")
+    @pytest.mark.benchmark
+    def test_tag_validator_no_regex_passes(self, mock_get_tags_at):
+        """An empty pattern deliberately disables the match."""
+        mock_get_tags_at.return_value = ["anything_goes"]
+        rule = ValidationRule(check="tag", regex=None)
+        validator = TagValidator(rule)
+        result = validator.validate(ValidationContext())
+        assert result == ValidationResult.PASS
+
+    @pytest.mark.benchmark
+    def test_tag_validator_pre_push_lines_extract_tag_refs(self):
+        """Pre-push stdin lines name the pushed tags, not literal tag names."""
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        stdin = "refs/tags/v1.2.3 abc123 refs/tags/v1.2.3 def456\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.PASS
+        assert validator._checked_value == "v1.2.3"
+
+    @pytest.mark.benchmark
+    def test_tag_validator_pre_push_bad_tag_fails(self):
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        validator._suppress_output = True
+        stdin = "refs/tags/bad_tag abc123 refs/tags/bad_tag def456\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.FAIL
+
+    @pytest.mark.benchmark
+    def test_tag_validator_pre_push_branch_only_skips(self):
+        """A push carrying no tag refs has nothing to validate."""
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        stdin = "refs/heads/main abc123 refs/heads/main def456\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.SKIP
+
+    @pytest.mark.benchmark
+    def test_tag_validator_pre_push_tag_deletion_skips(self):
+        """Deleting a tag removes a name rather than creating one."""
+        rule = ValidationRule(check="tag", regex=r"^v\d+\.\d+\.\d+$")
+        validator = TagValidator(rule)
+        zero = "0" * 40
+        stdin = f"(delete) {zero} refs/tags/bad_tag def456\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.SKIP

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1203,3 +1203,40 @@ class TestReconfigureIO:
         assert sys.stdout.encoding.upper() == "UTF-8"
         assert sys.stderr.encoding.upper() == "UTF-8"
         assert sys.stdin.encoding.upper() == "UTF-8"
+
+
+class TestTagFlag:
+    """Tests for the -t/--tag check type."""
+
+    def test_tag_flag_in_help(self, capfd, monkeypatch):
+        """The --tag flag and its option group appear in help output."""
+        monkeypatch.setattr("sys.argv", [CMD, "--help"])
+        with pytest.raises(SystemExit):
+            main()
+        out, _ = capfd.readouterr()
+        assert "--tag" in out
+        assert "--tag-regex" in out
+        assert "tag(s) pointing at HEAD" in out
+
+    def test_tag_in_requested_checks(self):
+        """-t requests exactly the tag check."""
+        from commit_check.main import _get_parser, _get_requested_checks
+
+        args = _get_parser().parse_args(["-t"])
+        assert _get_requested_checks(args) == ["tag"]
+
+    def test_tag_combines_with_branch(self):
+        """-b -t requests branch, merge_base and tag checks."""
+        from commit_check.main import _get_parser, _get_requested_checks
+
+        args = _get_parser().parse_args(["-b", "-t"])
+        assert _get_requested_checks(args) == ["branch", "merge_base", "tag"]
+
+    def test_tag_regex_reaches_config(self):
+        """--tag-regex overrides the [tag] section pattern."""
+        from commit_check.main import _get_parser
+        from commit_check.config_merger import ConfigMerger
+
+        args = _get_parser().parse_args(["-t", "--tag-regex", r"^rel-\d+$"])
+        config = ConfigMerger.parse_cli_args(args)
+        assert config["tag"]["regex"] == r"^rel-\d+$"

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -472,3 +472,51 @@ class TestLengthRuleMessages:
         assert "{" not in (rule.error or "")
         assert "{" not in (rule.suggest or "")
         assert "40" in (rule.suggest or "")
+
+
+class TestTagRules:
+    @pytest.mark.benchmark
+    def test_tag_rule_built_with_default_regex(self):
+        """With no [tag] config the rule carries the SemVer default."""
+        from commit_check import DEFAULT_TAG_REGEX
+
+        builder = RuleBuilder({})
+        rules = builder.build_all_rules()
+        tag_rules = [r for r in rules if r.check == "tag"]
+        assert len(tag_rules) == 1
+        assert tag_rules[0].regex == DEFAULT_TAG_REGEX
+        assert tag_rules[0].rule_id == "CC401"
+        assert tag_rules[0].docs_url == "https://commit-check.com/rules/#cc401"
+
+    @pytest.mark.benchmark
+    def test_tag_rule_custom_regex(self):
+        """A [tag] regex in config replaces the default."""
+        builder = RuleBuilder({"tag": {"regex": r"^rel-\d+$"}})
+        rules = builder.build_all_rules()
+        tag_rule = next(r for r in rules if r.check == "tag")
+        assert tag_rule.regex == r"^rel-\d+$"
+
+    @pytest.mark.benchmark
+    def test_tag_rule_empty_regex_disables_pattern(self):
+        """An empty regex deliberately disables the pattern match."""
+        builder = RuleBuilder({"tag": {"regex": ""}})
+        rules = builder.build_all_rules()
+        tag_rule = next(r for r in rules if r.check == "tag")
+        assert tag_rule.regex is None
+
+    @pytest.mark.benchmark
+    def test_default_tag_regex_accepts_semver_forms(self):
+        """The default accepts v-prefixed and bare SemVer, with suffixes."""
+        import re
+        from commit_check import DEFAULT_TAG_REGEX
+
+        for good in [
+            "v1.2.3",
+            "1.2.3",
+            "v1.2.3-rc.1",
+            "v1.2.3+build.5",
+            "v10.20.30-beta.2+exp.sha.5114f85",
+        ]:
+            assert re.match(DEFAULT_TAG_REGEX, good), good
+        for bad in ["release", "v1.2", "v1.2.3-", "v1.2.3+", "va.b.c", "v1.2.3 "]:
+            assert not re.match(DEFAULT_TAG_REGEX, bad), bad

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -513,10 +513,42 @@ class TestTagRules:
         for good in [
             "v1.2.3",
             "1.2.3",
+            "v0.1.0",
             "v1.2.3-rc.1",
+            "v1.2.3-0",
             "v1.2.3+build.5",
             "v10.20.30-beta.2+exp.sha.5114f85",
         ]:
             assert re.match(DEFAULT_TAG_REGEX, good), good
-        for bad in ["release", "v1.2", "v1.2.3-", "v1.2.3+", "va.b.c", "v1.2.3 "]:
+        # Leading zeroes in version-core numbers and numeric pre-release
+        # identifiers are forbidden by SemVer.
+        for bad in [
+            "release",
+            "v1.2",
+            "v1.2.3-",
+            "v1.2.3+",
+            "va.b.c",
+            "v1.2.3 ",
+            "v01.2.3",
+            "v1.02.3",
+            "v1.2.3-01",
+        ]:
             assert not re.match(DEFAULT_TAG_REGEX, bad), bad
+
+    @pytest.mark.benchmark
+    def test_tag_rule_non_mapping_section_falls_back(self):
+        """A malformed non-table [tag] value falls back to defaults."""
+        from commit_check import DEFAULT_TAG_REGEX
+
+        builder = RuleBuilder({"tag": "not-a-table"})
+        tag_rule = next(r for r in builder.build_all_rules() if r.check == "tag")
+        assert tag_rule.regex == DEFAULT_TAG_REGEX
+
+    @pytest.mark.benchmark
+    def test_tag_rule_non_string_regex_falls_back(self):
+        """A non-string regex value falls back to the default pattern."""
+        from commit_check import DEFAULT_TAG_REGEX
+
+        builder = RuleBuilder({"tag": {"regex": 123}})
+        tag_rule = next(r for r in builder.build_all_rules() if r.check == "tag")
+        assert tag_rule.regex == DEFAULT_TAG_REGEX

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -6,6 +6,7 @@ import subprocess
 import commit_check
 from commit_check import supports_color
 from commit_check.util import (
+    get_tags_at,
     fetch_remote_ref,
     fetch_upstream_ref,
     get_branch_name,
@@ -989,3 +990,62 @@ class TestGetGitConfigValue:
         mocker.patch("commit_check.util.cmd_output", return_value="alice@example.com\n")
         result = get_git_config_value("user.email")
         assert result == "alice@example.com"
+
+
+class TestGetTagsAt:
+    @pytest.mark.benchmark
+    def test_get_tags_at_lists_tags(self, mocker):
+        m_cmd_output = mocker.patch(
+            "commit_check.util.cmd_output", return_value="v1.0.0\nv1.0.1\n"
+        )
+        retval = get_tags_at()
+        assert m_cmd_output.call_args[0][0] == ["git", "tag", "--points-at", "HEAD"]
+        assert retval == ["v1.0.0", "v1.0.1"]
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_passes_rev(self, mocker):
+        m_cmd_output = mocker.patch(
+            "commit_check.util.cmd_output", return_value="v2.0.0\n"
+        )
+        retval = get_tags_at("abc123")
+        assert m_cmd_output.call_args[0][0] == ["git", "tag", "--points-at", "abc123"]
+        assert retval == ["v2.0.0"]
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_no_tags(self, mocker, monkeypatch):
+        monkeypatch.delenv("GITHUB_REF_TYPE", raising=False)
+        mocker.patch("commit_check.util.cmd_output", return_value="")
+        assert get_tags_at() == []
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_git_error(self, mocker, monkeypatch):
+        monkeypatch.delenv("GITHUB_REF_TYPE", raising=False)
+        mocker.patch(
+            "commit_check.util.cmd_output",
+            side_effect=CalledProcessError(returncode=128, cmd="git tag"),
+        )
+        assert get_tags_at() == []
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_github_actions_tag_fallback(self, mocker, monkeypatch):
+        """A tag build's ref name stands in when the local repo has no tag ref."""
+        mocker.patch("commit_check.util.cmd_output", return_value="")
+        monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
+        monkeypatch.setenv("GITHUB_REF_NAME", "v3.0.0")
+        assert get_tags_at() == ["v3.0.0"]
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_env_ignored_for_branch_builds(self, mocker, monkeypatch):
+        """A branch build's ref name is not a tag and must not stand in."""
+        mocker.patch("commit_check.util.cmd_output", return_value="")
+        monkeypatch.setenv("GITHUB_REF_TYPE", "branch")
+        monkeypatch.setenv("GITHUB_REF_NAME", "main")
+        assert get_tags_at() == []
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_local_tags_outrank_env(self, mocker, monkeypatch):
+        """Real local tags win over the environment fallback."""
+        mocker.patch("commit_check.util.cmd_output", return_value="v1.0.0\n")
+        monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
+        monkeypatch.setenv("GITHUB_REF_NAME", "v9.9.9")
+        assert get_tags_at() == ["v1.0.0"]

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -993,43 +993,51 @@ class TestGetGitConfigValue:
 
 
 class TestGetTagsAt:
+    @staticmethod
+    def _git_result(mocker, returncode, stdout):
+        return mocker.patch(
+            "commit_check.util.subprocess.run",
+            return_value=mocker.Mock(returncode=returncode, stdout=stdout, stderr=""),
+        )
+
     @pytest.mark.benchmark
     def test_get_tags_at_lists_tags(self, mocker):
-        m_cmd_output = mocker.patch(
-            "commit_check.util.cmd_output", return_value="v1.0.0\nv1.0.1\n"
-        )
+        m_run = self._git_result(mocker, 0, "v1.0.0\nv1.0.1\n")
         retval = get_tags_at()
-        assert m_cmd_output.call_args[0][0] == ["git", "tag", "--points-at", "HEAD"]
+        assert m_run.call_args[0][0] == ["git", "tag", "--points-at", "HEAD"]
         assert retval == ["v1.0.0", "v1.0.1"]
 
     @pytest.mark.benchmark
     def test_get_tags_at_passes_rev(self, mocker):
-        m_cmd_output = mocker.patch(
-            "commit_check.util.cmd_output", return_value="v2.0.0\n"
-        )
+        m_run = self._git_result(mocker, 0, "v2.0.0\n")
         retval = get_tags_at("abc123")
-        assert m_cmd_output.call_args[0][0] == ["git", "tag", "--points-at", "abc123"]
+        assert m_run.call_args[0][0] == ["git", "tag", "--points-at", "abc123"]
         assert retval == ["v2.0.0"]
 
     @pytest.mark.benchmark
     def test_get_tags_at_no_tags(self, mocker, monkeypatch):
         monkeypatch.delenv("GITHUB_REF_TYPE", raising=False)
-        mocker.patch("commit_check.util.cmd_output", return_value="")
+        self._git_result(mocker, 0, "")
         assert get_tags_at() == []
 
     @pytest.mark.benchmark
-    def test_get_tags_at_git_error(self, mocker, monkeypatch):
+    def test_get_tags_at_git_error_is_not_a_tag(self, mocker, monkeypatch):
+        """A git diagnostic on nonzero exit must not be parsed as a tag name."""
         monkeypatch.delenv("GITHUB_REF_TYPE", raising=False)
         mocker.patch(
-            "commit_check.util.cmd_output",
-            side_effect=CalledProcessError(returncode=128, cmd="git tag"),
+            "commit_check.util.subprocess.run",
+            return_value=mocker.Mock(
+                returncode=128,
+                stdout="",
+                stderr="fatal: bad revision 'HEAD'",
+            ),
         )
         assert get_tags_at() == []
 
     @pytest.mark.benchmark
     def test_get_tags_at_github_actions_tag_fallback(self, mocker, monkeypatch):
         """A tag build's ref name stands in when the local repo has no tag ref."""
-        mocker.patch("commit_check.util.cmd_output", return_value="")
+        self._git_result(mocker, 0, "")
         monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
         monkeypatch.setenv("GITHUB_REF_NAME", "v3.0.0")
         assert get_tags_at() == ["v3.0.0"]
@@ -1037,15 +1045,33 @@ class TestGetTagsAt:
     @pytest.mark.benchmark
     def test_get_tags_at_env_ignored_for_branch_builds(self, mocker, monkeypatch):
         """A branch build's ref name is not a tag and must not stand in."""
-        mocker.patch("commit_check.util.cmd_output", return_value="")
+        self._git_result(mocker, 0, "")
         monkeypatch.setenv("GITHUB_REF_TYPE", "branch")
         monkeypatch.setenv("GITHUB_REF_NAME", "main")
         assert get_tags_at() == []
 
     @pytest.mark.benchmark
+    def test_get_tags_at_env_ignored_for_other_rev(self, mocker, monkeypatch):
+        """--rev at another commit must not borrow the event's tag name."""
+        self._git_result(mocker, 0, "")
+        monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
+        monkeypatch.setenv("GITHUB_REF_NAME", "v3.0.0")
+        monkeypatch.setenv("GITHUB_SHA", "workflowsha")
+        assert get_tags_at("othersha") == []
+
+    @pytest.mark.benchmark
+    def test_get_tags_at_env_applies_to_workflow_sha(self, mocker, monkeypatch):
+        """The workflow's own revision may borrow the event's tag name."""
+        self._git_result(mocker, 0, "")
+        monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
+        monkeypatch.setenv("GITHUB_REF_NAME", "v3.0.0")
+        monkeypatch.setenv("GITHUB_SHA", "workflowsha")
+        assert get_tags_at("workflowsha") == ["v3.0.0"]
+
+    @pytest.mark.benchmark
     def test_get_tags_at_local_tags_outrank_env(self, mocker, monkeypatch):
         """Real local tags win over the environment fallback."""
-        mocker.patch("commit_check.util.cmd_output", return_value="v1.0.0\n")
+        self._git_result(mocker, 0, "v1.0.0\n")
         monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
         monkeypatch.setenv("GITHUB_REF_NAME", "v9.9.9")
         assert get_tags_at() == ["v1.0.0"]


### PR DESCRIPTION
## Summary

Implements #557: tag name validation, opening the `CC4xx` rule range with **CC401**. GitHub gates tag name patterns behind Enterprise-plan metadata restrictions; this brings the same policy to every plan and forge, closing the last ref-naming gap next to the branch rules.

### How it works

- **`--tag` / `-t`** validates every tag pointing at the revision under test (`--rev`, or `HEAD`). A commit with no tag is a **skip**, not a failure — the rule validates how tags are named, and the absence of one is not a naming violation.
- **Pattern sources**, in the usual precedence: `--tag-regex` > `CCHK_TAG_REGEX` > `[tag] regex` in TOML > default. The default accepts SemVer with an optional leading `v` (`v1.2.3` or `1.2.3`, pre-release and build-metadata suffixes included). An empty pattern deliberately disables the match.
- **Piped input** names tags directly, one per line. When the lines are the four-field refs a pre-push hook receives, the tags under push are extracted from `refs/tags/*` instead — so the new **`check-tag` pre-commit hook** (`stages: [pre-push]`) validates exactly what a push carries. Tag deletions are exempt: they remove a name rather than creating one.
- **GitHub Actions tag builds**: when a shallow checkout doesn't carry the tag ref, `GITHUB_REF_NAME` (guarded by `GITHUB_REF_TYPE=tag`) stands in.
- **`validate_tag()`** joins the public Python API; JSON output carries `rule_id: CC401` and the docs URL like every other rule.

### Notes for release

- The rules reference on commit-check.com needs a CC401 section when this ships — the site's docs-sync suite will flag it against the released version, and `docs_url` already points at `https://commit-check.com/rules/#cc401`.
- README pins stay at v2.15.1 per AGENTS.md (they track the latest published release; the release PR bumps them). The `check-tag` snippet becomes installable once the release containing the hook exists.

## Testing

- 34 new tests across engine (validator incl. pre-push parsing), rule_builder (default/custom/empty regex, default-regex accept/reject matrix), util (`get_tags_at` incl. env fallback precedence), api, main (flag parsing, help), config_merger (env + defaults)
- Full suite: 630 passed; the one failure (`test_load_config_file_permission_error`) is a sandbox artifact — this environment runs as root, which ignores `chmod 000`, and it fails identically on a clean `main` checkout
- `pre-commit run` clean across changed files (ruff check/format, mypy, codespell, yaml)
- End-to-end verified in scratch repos: fail on bad tag at HEAD, pass via `--rev` on an older tagged commit, skip with exit 0 on untagged commits, piped and multi-tag behavior, `GITHUB_REF_TYPE` fallback, JSON output shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-name validation with the `--tag`/`-t` option.
  * Supports custom tag patterns through configuration, environment variables, or `--tag-regex`.
  * Added API support for validating tags, including tags at `HEAD`.
  * Added a pre-push hook for automatic tag checks.
* **Documentation**
  * Documented tag validation, configuration options, CI usage, and hook integration.
* **Tests**
  * Added coverage for tag validation, configuration, CLI options, API behavior, and hook handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->