### PR TITLE
feat: add file metadata checks (CC302-CC304)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,3 +44,12 @@
   pass_filenames: false
   always_run: true
   language: python
+- id: check-files
+  name: check committed files
+  description: ensures committed files respect size, path pattern and path length policies
+  entry: commit-check
+  args: [--files]
+  stages: [pre-push]
+  pass_filenames: false
+  always_run: true
+  language: python

--- a/README.md
+++ b/README.md
@@ -294,6 +294,21 @@ commit-check --files
 commit-check --files --rev abc1234
 ```
 
+```yaml
+# In pre-commit hooks (.pre-commit-config.yaml): a native git pre-push hook
+# feeds the pushed refs on stdin, and each pushed tip is validated
+repos:
+  - repo: https://github.com/commit-check/commit-check
+    rev: v2.15.1
+    hooks:
+      - id: check-files
+        stages: [pre-push]
+```
+
+> [!NOTE]
+> Like `check-tag`, the `check-files` hook ships in the first release after
+> v2.15.1 — bump `rev` to that release once it is published.
+
 A commit that only deletes files is reported as skipped — removing a file
 adds nothing to police. Content scanning (entropy, token detection) is
 deliberately out of scope: pair these checks with a scanner like gitleaks

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ max_size = "5MB"
 
 # Reject paths matching any fnmatch pattern; a bare pattern like *.pem
 # also matches the file name at any depth
+# Patterns are case-sensitive on every platform, like git pathspecs
 prohibited_patterns = ["*.pem", "*.key", ".env", "id_rsa*"]
 
 # Reject paths longer than this many characters

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ commit-check --files --rev abc1234
 ```yaml
 # In pre-commit hooks (.pre-commit-config.yaml): a native git pre-push hook
 # feeds the pushed refs on stdin, and every commit the push adds is validated
-# (tag pushes are left to check-tag, which polices tag names)
+# (a tag on already-pushed history adds nothing, so it is skipped)
 repos:
   - repo: https://github.com/commit-check/commit-check
     rev: v2.15.1

--- a/README.md
+++ b/README.md
@@ -296,7 +296,8 @@ commit-check --files --rev abc1234
 
 ```yaml
 # In pre-commit hooks (.pre-commit-config.yaml): a native git pre-push hook
-# feeds the pushed refs on stdin, and each pushed tip is validated
+# feeds the pushed refs on stdin, and every commit the push adds is validated
+# (tag pushes are left to check-tag, which polices tag names)
 repos:
   - repo: https://github.com/commit-check/commit-check
     rev: v2.15.1

--- a/README.md
+++ b/README.md
@@ -267,6 +267,38 @@ repos:
 > The `check-tag` hook ships in the first release after v2.15.1 — bump `rev`
 > to that release once it is published.
 
+### Check Committed Files
+
+Use `--files` to police metadata about the files a commit touches — never
+their contents. Three independent, opt-in limits live in the `[files]`
+config section: a size cap, prohibited path patterns, and a path-length
+cap. GitHub's own push rules do this only on Team and Enterprise plans;
+here it works on every plan and every forge.
+
+```toml
+[files]
+# Reject files larger than this (bytes, or with a KB/MB/GB suffix)
+max_size = "5MB"
+
+# Reject paths matching any fnmatch pattern; a bare pattern like *.pem
+# also matches the file name at any depth
+prohibited_patterns = ["*.pem", "*.key", ".env", "id_rsa*"]
+
+# Reject paths longer than this many characters
+max_path_length = 250
+```
+
+```bash
+# Validate the commit at HEAD, or any commit via --rev
+commit-check --files
+commit-check --files --rev abc1234
+```
+
+A commit that only deletes files is reported as skipped — removing a file
+adds nothing to police. Content scanning (entropy, token detection) is
+deliberately out of scope: pair these checks with a scanner like gitleaks
+if you need it.
+
 ## AI-Native Usage
 
 Commit Check is designed to be consumed by AI agents, LLM toolchains, and
@@ -589,6 +621,7 @@ reflects a DIY approach rather than built-in product features.
 | Conventional Commits enforcement | ✅ | ✅ | Partial | Partial[^4] | DIY |
 | Branch naming validation | ✅ | ❌ | ✅ | ✅[^4] | DIY |
 | Tag naming validation | ✅ | ❌ | ❌ | ✅[^4] | DIY |
+| File size / path restrictions | ✅ | ❌ | ❌ | ✅[^5] | DIY |
 | Force push blocking | ✅ | ❌ | ❌ | ✅ | DIY |
 | Author name / email validation | ✅ | ❌ | ✅ | ✅[^4] | DIY |
 | Signed-off-by trailer enforcement | ✅ | Partial[^1] | ❌ | ❌ | DIY |

--- a/commit_check/config_merger.py
+++ b/commit_check/config_merger.py
@@ -95,6 +95,11 @@ def get_default_config() -> dict[str, Any]:
         "tag": {
             "regex": DEFAULT_TAG_REGEX,
         },
+        "files": {
+            "max_size": "",
+            "prohibited_patterns": [],
+            "max_path_length": 0,
+        },
     }
 
 
@@ -141,6 +146,10 @@ class ConfigMerger:
         "CCHK_ALLOW_FORCE_PUSH": ("push", "allow_force_push", parse_bool),
         # Tag section
         "CCHK_TAG_REGEX": ("tag", "regex", str),
+        # Files section
+        "CCHK_FILES_MAX_SIZE": ("files", "max_size", str),
+        "CCHK_FILES_PROHIBITED_PATTERNS": ("files", "prohibited_patterns", parse_list),
+        "CCHK_FILES_MAX_PATH_LENGTH": ("files", "max_path_length", parse_int),
     }
 
     # Mapping of CLI argument names to config keys
@@ -173,12 +182,22 @@ class ConfigMerger:
         "allow_force_push": ("push", "allow_force_push"),
         # Tag section
         "tag_regex": ("tag", "regex"),
+        # Files section
+        "files_max_size": ("files", "max_size"),
+        "files_prohibited_patterns": ("files", "prohibited_patterns"),
+        "files_max_path_length": ("files", "max_path_length"),
     }
 
     @staticmethod
     def parse_env_vars() -> dict[str, Any]:
         """Parse environment variables with CCHK_ prefix into config dict."""
-        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}, "tag": {}}
+        config: dict[str, Any] = {
+            "commit": {},
+            "branch": {},
+            "push": {},
+            "tag": {},
+            "files": {},
+        }
 
         for env_var, (section, key, parser) in ConfigMerger.ENV_VAR_MAPPING.items():
             value = os.environ.get(env_var)
@@ -197,7 +216,13 @@ class ConfigMerger:
     @staticmethod
     def parse_cli_args(args: argparse.Namespace) -> dict[str, Any]:
         """Parse CLI arguments into config dict."""
-        config: dict[str, Any] = {"commit": {}, "branch": {}, "push": {}, "tag": {}}
+        config: dict[str, Any] = {
+            "commit": {},
+            "branch": {},
+            "push": {},
+            "tag": {},
+            "files": {},
+        }
 
         for arg_name, (section, key) in ConfigMerger.CLI_ARG_MAPPING.items():
             if hasattr(args, arg_name):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -17,8 +17,10 @@ from commit_check.util import (
     get_commit_info,
     get_git_config_value,
     get_branch_name,
+    get_commit_files,
     get_git_remotes,
     get_tags_at,
+    format_size,
     get_upstream_branch,
     get_upstream_remote_sha,
     has_commits,
@@ -668,6 +670,83 @@ class TagValidator(BaseValidator):
         return ValidationResult.PASS
 
 
+class FilesValidator(BaseValidator):
+    """Validates metadata about the files a commit touches.
+
+    One class serves the three file rules — size limit, prohibited path
+    patterns, path length — branching on the rule's check name. Only the
+    paths and sizes recorded in the commit are read, never file contents:
+    content scanning is a different tool's job. A commit touching no files
+    (or an unresolvable revision) is a skip.
+    """
+
+    def validate(self, context: ValidationContext) -> ValidationResult:
+        files = get_commit_files(context.rev or "HEAD")
+        if not files:
+            return ValidationResult.SKIP
+
+        self._checked_value = f"{len(files)} file(s)"
+
+        if self.rule.check == "file_size":
+            return self._validate_sizes(files)
+        if self.rule.check == "file_pattern":
+            return self._validate_patterns(files)
+        if self.rule.check == "path_length":
+            return self._validate_path_lengths(files)
+        return ValidationResult.PASS
+
+    def _fail(self, offenders: list[str]) -> ValidationResult:
+        """Report the first offender, with a count when there are more."""
+        value = offenders[0]
+        if len(offenders) > 1:
+            value += f" (+{len(offenders) - 1} more)"
+        self._checked_value = value
+        self._print_failure(value)
+        return ValidationResult.FAIL
+
+    def _validate_sizes(self, files: list[tuple[str, int]]) -> ValidationResult:
+        limit = self.rule.value
+        offenders = [
+            f"{path} ({format_size(size)})" for path, size in files if size > limit
+        ]
+        if offenders:
+            return self._fail(offenders)
+        return ValidationResult.PASS
+
+    def _validate_patterns(self, files: list[tuple[str, int]]) -> ValidationResult:
+        from fnmatch import fnmatch
+
+        patterns = self.rule.value or []
+        offenders = []
+        for path, _ in files:
+            basename = path.rsplit("/", 1)[-1]
+            hit = next(
+                (
+                    pattern
+                    for pattern in patterns
+                    # A bare pattern like *.pem should catch the file at any
+                    # depth, so the basename is matched alongside the full
+                    # path.
+                    if fnmatch(path, pattern) or fnmatch(basename, pattern)
+                ),
+                None,
+            )
+            if hit:
+                offenders.append(f"{path} (pattern {hit})")
+        if offenders:
+            return self._fail(offenders)
+        return ValidationResult.PASS
+
+    def _validate_path_lengths(self, files: list[tuple[str, int]]) -> ValidationResult:
+        limit = self.rule.value
+        offenders = [
+            f"{path} ({len(path)} characters)" for path, _ in files if len(path) > limit
+        ]
+        if offenders:
+            return self._fail(offenders)
+        return ValidationResult.PASS
+
+
 class MergeBaseValidator(BaseValidator):
     """Validates merge base ancestry."""
 
@@ -1114,6 +1193,9 @@ class ValidationEngine:
         "no_force_push": ForcePushValidator,
         "ai_attribution": AiAttributionValidator,
         "tag": TagValidator,
+        "file_size": FilesValidator,
+        "file_pattern": FilesValidator,
+        "path_length": FilesValidator,
     }
 
     def __init__(self, rules: list[ValidationRule]):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -18,6 +18,7 @@ from commit_check.util import (
     get_git_config_value,
     get_branch_name,
     get_commit_files,
+    get_push_commits,
     get_git_remotes,
     get_tags_at,
     format_size,
@@ -66,6 +67,12 @@ class ValidationContext:
     # check. The CLI verifies the revision resolves before it gets here.
     # Last on purpose: positional construction predates it.
     rev: str | None = None
+    # Per-run memo of get_commit_files() keyed by revision. The three file
+    # rules each get their own validator, so without this they would re-run
+    # the same git plumbing over the same commits three times.
+    files_cache: dict[str, list[tuple[str, int]]] = field(
+        default_factory=dict, repr=False, compare=False
+    )
 
 
 @dataclass
@@ -682,40 +689,61 @@ class FilesValidator(BaseValidator):
 
     @staticmethod
     def _push_revs_from_stdin(text: str) -> list[str] | None:
-        """Extract the pushed commit shas from pre-push hook input.
+        """Extract the commits a pre-push hook is being asked to approve.
 
         A native pre-push hook receives ``<local ref> <sha> <remote ref>
-        <sha>`` lines naming what is actually being pushed; validating HEAD
-        there would check the wrong commit whenever another ref is pushed.
-        Deletions (all-zero local sha) remove content rather than adding
-        it. Input of any other shape is not push metadata and returns
-        ``None``, so the validator falls back to the revision under test.
+        <sha>`` lines naming what is being pushed; validating HEAD there
+        would check the wrong commit whenever another ref is pushed. Both
+        ends of each line matter: a push usually carries several commits,
+        and checking only the tip would wave through a file added by any
+        earlier commit in the same push.
+
+        Skipped are deletions (an all-zero local sha removes content rather
+        than adding it) and tag refs — a tag names history that was already
+        pushed and checked, so re-diffing it would reject ``git push
+        --follow-tags`` over a file committed long before. Tag *names* are
+        CC401's business.
+
+        Input of any other shape is not push metadata and returns ``None``,
+        so the validator falls back to the revision under test.
         """
         lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
         push_lines = [ln for ln in lines if len(ln.split()) == 4 and "refs/" in ln]
         if not push_lines or len(push_lines) != len(lines):
             return None
-        revs = []
+        revs: list[str] = []
         for ln in push_lines:
-            _, local_sha, _, _ = ln.split()
-            if set(local_sha) == {"0"}:
+            local_ref, local_sha, _remote_ref, remote_sha = ln.split()
+            if set(local_sha) == {"0"} or local_ref.startswith("refs/tags/"):
                 continue
-            revs.append(local_sha)
+            revs.extend(get_push_commits(local_sha, remote_sha))
         return list(dict.fromkeys(revs))
+
+    def _files_for_rev(self, context: ValidationContext, rev: str):
+        """Files touched by *rev*, computed once per run and shared."""
+        if rev not in context.files_cache:
+            context.files_cache[rev] = get_commit_files(rev)
+        return context.files_cache[rev]
 
     def validate(self, context: ValidationContext) -> ValidationResult:
         revs = None
         if context.stdin_text is not None:
             revs = self._push_revs_from_stdin(context.stdin_text)
             if revs is not None and not revs:
-                # A push carrying only deletions adds nothing to police.
+                # A push carrying only deletions, tags, or commits the
+                # remote already has adds nothing to police.
                 return ValidationResult.SKIP
         if revs is None:
             revs = [context.rev or "HEAD"]
 
-        files = []
+        # A file touched by several commits in one push is one offender.
+        files: list[tuple[str, int]] = []
+        seen: set[tuple[str, int]] = set()
         for rev in revs:
-            files.extend(get_commit_files(rev))
+            for item in self._files_for_rev(context, rev):
+                if item not in seen:
+                    seen.add(item)
+                    files.append(item)
         if not files:
             return ValidationResult.SKIP
 

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -719,7 +719,9 @@ class FilesValidator(BaseValidator):
             revs.extend(get_push_commits(local_sha, remote_sha))
         return list(dict.fromkeys(revs))
 
-    def _files_for_rev(self, context: ValidationContext, rev: str):
+    def _files_for_rev(
+        self, context: ValidationContext, rev: str
+    ) -> list[tuple[str, int]]:
         """Files touched by *rev*, computed once per run and shared."""
         if rev not in context.files_cache:
             context.files_cache[rev] = get_commit_files(rev)

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -800,7 +800,11 @@ class FilesValidator(BaseValidator):
         return ValidationResult.PASS
 
     def _validate_patterns(self, files: list[tuple[str, int]]) -> ValidationResult:
-        from fnmatch import fnmatch
+        # fnmatch() folds case through os.path.normcase, which would make
+        # "*.pem" catch KEY.PEM on Windows and miss it everywhere else --
+        # one config, two policies. fnmatchcase() is the same on every
+        # platform, and case-sensitive is what git pathspecs already are.
+        from fnmatch import fnmatchcase
 
         patterns = self.rule.value or []
         offenders = []
@@ -813,7 +817,7 @@ class FilesValidator(BaseValidator):
                     # A bare pattern like *.pem should catch the file at any
                     # depth, so the basename is matched alongside the full
                     # path.
-                    if fnmatch(path, pattern) or fnmatch(basename, pattern)
+                    if fnmatchcase(path, pattern) or fnmatchcase(basename, pattern)
                 ),
                 None,
             )

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -680,8 +680,42 @@ class FilesValidator(BaseValidator):
     (or an unresolvable revision) is a skip.
     """
 
+    @staticmethod
+    def _push_revs_from_stdin(text: str) -> list[str] | None:
+        """Extract the pushed commit shas from pre-push hook input.
+
+        A native pre-push hook receives ``<local ref> <sha> <remote ref>
+        <sha>`` lines naming what is actually being pushed; validating HEAD
+        there would check the wrong commit whenever another ref is pushed.
+        Deletions (all-zero local sha) remove content rather than adding
+        it. Input of any other shape is not push metadata and returns
+        ``None``, so the validator falls back to the revision under test.
+        """
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        push_lines = [ln for ln in lines if len(ln.split()) == 4 and "refs/" in ln]
+        if not push_lines or len(push_lines) != len(lines):
+            return None
+        revs = []
+        for ln in push_lines:
+            _, local_sha, _, _ = ln.split()
+            if set(local_sha) == {"0"}:
+                continue
+            revs.append(local_sha)
+        return list(dict.fromkeys(revs))
+
     def validate(self, context: ValidationContext) -> ValidationResult:
-        files = get_commit_files(context.rev or "HEAD")
+        revs = None
+        if context.stdin_text is not None:
+            revs = self._push_revs_from_stdin(context.stdin_text)
+            if revs is not None and not revs:
+                # A push carrying only deletions adds nothing to police.
+                return ValidationResult.SKIP
+        if revs is None:
+            revs = [context.rev or "HEAD"]
+
+        files = []
+        for rev in revs:
+            files.extend(get_commit_files(rev))
         if not files:
             return ValidationResult.SKIP
 

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -698,11 +698,16 @@ class FilesValidator(BaseValidator):
         and checking only the tip would wave through a file added by any
         earlier commit in the same push.
 
-        Skipped are deletions (an all-zero local sha removes content rather
-        than adding it) and tag refs — a tag names history that was already
-        pushed and checked, so re-diffing it would reject ``git push
-        --follow-tags`` over a file committed long before. Tag *names* are
-        CC401's business.
+        Deletions are skipped: an all-zero local sha removes content rather
+        than adding it.
+
+        Tags go through the same range as branches rather than being
+        skipped. What matters is not whether a ref is a tag but whether it
+        carries commits the remote lacks: a tag on already-pushed history
+        resolves to an empty range, so ``git push --follow-tags`` is not
+        rejected over a file committed long before, while a tag that is the
+        only thing carrying a commit to the remote still gets that commit
+        checked. Tag *names* remain CC401's business.
 
         Input of any other shape is not push metadata and returns ``None``,
         so the validator falls back to the revision under test.
@@ -713,8 +718,8 @@ class FilesValidator(BaseValidator):
             return None
         revs: list[str] = []
         for ln in push_lines:
-            local_ref, local_sha, _remote_ref, remote_sha = ln.split()
-            if set(local_sha) == {"0"} or local_ref.startswith("refs/tags/"):
+            _local_ref, local_sha, _remote_ref, remote_sha = ln.split()
+            if set(local_sha) == {"0"}:
                 continue
             revs.extend(get_push_commits(local_sha, remote_sha))
         return list(dict.fromkeys(revs))

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -732,18 +732,27 @@ class FilesValidator(BaseValidator):
             context.files_cache[rev] = get_commit_files(rev)
         return context.files_cache[rev]
 
-    def validate(self, context: ValidationContext) -> ValidationResult:
-        revs = None
+    def _revs_to_check(self, context: ValidationContext) -> list[str] | None:
+        """Revisions this run should police.
+
+        ``None`` means the push carried nothing to police — only deletions,
+        or commits the remote already has — which the caller reports as a
+        skip rather than a pass.
+        """
         if context.stdin_text is not None:
             revs = self._push_revs_from_stdin(context.stdin_text)
-            if revs is not None and not revs:
-                # A push carrying only deletions, tags, or commits the
-                # remote already has adds nothing to police.
-                return ValidationResult.SKIP
-        if revs is None:
-            revs = [context.rev or "HEAD"]
+            if revs is not None:
+                return revs or None
+        return [context.rev or "HEAD"]
 
-        # A file touched by several commits in one push is one offender.
+    def _collect_files(
+        self, context: ValidationContext, revs: list[str]
+    ) -> list[tuple[str, int]]:
+        """Files across *revs*, each one counted once.
+
+        A file touched by several commits of the same push is one offender,
+        not one per commit.
+        """
         files: list[tuple[str, int]] = []
         seen: set[tuple[str, int]] = set()
         for rev in revs:
@@ -751,6 +760,14 @@ class FilesValidator(BaseValidator):
                 if item not in seen:
                     seen.add(item)
                     files.append(item)
+        return files
+
+    def validate(self, context: ValidationContext) -> ValidationResult:
+        revs = self._revs_to_check(context)
+        if revs is None:
+            return ValidationResult.SKIP
+
+        files = self._collect_files(context, revs)
         if not files:
             return ValidationResult.SKIP
 

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -178,6 +178,16 @@ def _get_parser() -> argparse.ArgumentParser:
     )
 
     check_group.add_argument(
+        "-f",
+        "--files",
+        help="check the files the commit at HEAD (or --rev) touches: size "
+        "limit, prohibited path patterns, path length (all off until "
+        "configured in the [files] config section)",
+        action="store_true",
+        required=False,
+    )
+
+    check_group.add_argument(
         "-n",
         "--author-name",
         help="check git author name",
@@ -434,6 +444,38 @@ def _get_parser() -> argparse.ArgumentParser:
         "leading v, e.g. v1.2.3); an empty value disables the pattern match",
     )
 
+    # Files configuration options
+    files_group = parser.add_argument_group(
+        "files options", "Configuration options for --files validation"
+    )
+
+    files_group.add_argument(
+        "--files-max-size",
+        type=str,
+        default=None,
+        metavar="SIZE",
+        help="maximum size for a committed file, in bytes or with a unit "
+        "suffix (e.g. 5MB, 500KB)",
+    )
+
+    files_group.add_argument(
+        "--files-prohibited-patterns",
+        type=parse_list,
+        default=None,
+        metavar="LIST",
+        help="comma-separated fnmatch patterns committed paths must not "
+        "match (e.g. *.pem,.env,id_rsa*); a bare pattern also matches "
+        "the file name at any depth",
+    )
+
+    files_group.add_argument(
+        "--files-max-path-length",
+        type=int,
+        default=None,
+        metavar="INT",
+        help="maximum number of characters in a committed file path",
+    )
+
     return parser
 
 
@@ -497,6 +539,8 @@ def _get_requested_checks(args: argparse.Namespace) -> list[str]:
         requested_checks.extend(["branch", "merge_base"])
     if args.tag:
         requested_checks.append("tag")
+    if args.files:
+        requested_checks.extend(["file_size", "file_pattern", "path_length"])
     if args.author_name:
         requested_checks.append("author_name")
     if args.author_email:
@@ -579,6 +623,19 @@ def main() -> int:
 
         # Filter rules to only include requested checks
         filtered_rules = [rule for rule in all_rules if rule.check in requested_checks]
+
+        # The files rules exist only when configured, so --files with an
+        # empty [files] section would silently validate nothing — say so
+        # instead of letting the quiet pass read as a verdict.
+        if args.files and not any(
+            rule.check in ("file_size", "file_pattern", "path_length")
+            for rule in filtered_rules
+        ):
+            print(
+                "⊘ --files requested but nothing is configured in the [files] section",
+                file=sys.stderr,
+            )
+
         engine = ValidationEngine(filtered_rules)
 
         # Resolve validation context inputs. With --rev the commit itself is

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -502,13 +502,23 @@ def _resolve_stdin_for_non_message(
 ) -> str | None:
     """Resolve stdin content for non-message validation types."""
     has_non_message_check = any(
-        [args.branch, args.tag, args.author_name, args.author_email, args.no_force_push]
+        [
+            args.branch,
+            args.tag,
+            args.files,
+            args.author_name,
+            args.author_email,
+            args.no_force_push,
+        ]
     )
     if not has_non_message_check:
         return None
 
     stdin_content = stdin_reader.read_piped_input()
-    if args.no_force_push and stdin_content is None:
+    # Both push-shaped checks need the pre-push ref lines. Under the
+    # pre-commit framework git's native stdin is consumed, so the same data
+    # is rebuilt from the PRE_COMMIT_* environment.
+    if (args.no_force_push or args.files) and stdin_content is None:
         return _build_pre_commit_push_input()
     return stdin_content
 

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -132,7 +132,19 @@ class RuleBuilder:
         non-table section, an unparsable size, a non-list pattern set)
         disable the rule rather than failing every commit.
         """
-        files_config = self.files_config if isinstance(self.files_config, dict) else {}
+        if isinstance(self.files_config, dict):
+            files_config = self.files_config
+        else:
+            # A scalar [files] carries no settings to read, so every rule
+            # below would report "not configured" — say what is actually
+            # wrong instead of letting the section disappear silently.
+            if self.files_config:
+                print(
+                    f"⊘ [files] must be a table, got {self.files_config!r}; "
+                    "the file rules are disabled",
+                    file=sys.stderr,
+                )
+            files_config = {}
         builders = {
             "file_size": self._build_file_size_rule,
             "file_pattern": self._build_file_pattern_rule,

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -1,6 +1,7 @@
 """Rule builder that creates validation rules from config and catalog."""
 
 from __future__ import annotations
+import sys
 from typing import Any
 from dataclasses import dataclass
 from commit_check.rules_catalog import (
@@ -137,6 +138,12 @@ class RuleBuilder:
             "file_pattern": self._build_file_pattern_rule,
             "path_length": self._build_path_length_rule,
         }
+        #: The [files] key each rule reads, for reporting unusable values.
+        settings = {
+            "file_size": "max_size",
+            "file_pattern": "prohibited_patterns",
+            "path_length": "max_path_length",
+        }
 
         rules = []
         for catalog_entry in FILES_RULES:
@@ -144,6 +151,18 @@ class RuleBuilder:
             rule = builder(catalog_entry, files_config) if builder else None
             if rule:
                 rules.append(rule)
+                continue
+            # A value that was set but could not be used disables its rule.
+            # Staying quiet would leave a policy the author believes is in
+            # force silently absent, so name the setting and its value.
+            key = settings.get(catalog_entry.check)
+            configured = files_config.get(key) if key else None
+            if configured:
+                print(
+                    f"⊘ [files] {key} = {configured!r} is not usable; "
+                    f"{catalog_entry.rule_id} {catalog_entry.name} is disabled",
+                    file=sys.stderr,
+                )
         return rules
 
     @staticmethod

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -7,6 +7,7 @@ from commit_check.rules_catalog import (
     COMMIT_RULES,
     BRANCH_RULES,
     PUSH_RULES,
+    FILES_RULES,
     TAG_RULES,
     RULES_BY_CHECK,
     RuleCatalogEntry,
@@ -77,6 +78,7 @@ class RuleBuilder:
         self.branch_config = config.get("branch", {})
         self.push_config = config.get("push", {})
         self.tag_config = config.get("tag", {})
+        self.files_config = config.get("files", {})
 
     def build_all_rules(self) -> list[ValidationRule]:
         """Build all validation rules from config."""
@@ -84,6 +86,7 @@ class RuleBuilder:
         rules.extend(self._build_commit_rules())
         rules.extend(self._build_branch_rules())
         rules.extend(self._build_push_rules())
+        rules.extend(self._build_files_rules())
         rules.extend(self._build_tag_rules())
         return rules
 
@@ -117,6 +120,67 @@ class RuleBuilder:
             rule = self._build_push_rule(catalog_entry)
             if rule:
                 rules.append(rule)
+
+        return rules
+
+    def _build_files_rules(self) -> list[ValidationRule]:
+        """Build file-metadata validation rules.
+
+        All three are off by default: each rule exists only when its
+        [files] setting carries a usable value, and malformed values (a
+        non-table section, an unparsable size, a non-list pattern set)
+        disable the rule rather than failing every commit.
+        """
+        from commit_check.util import format_size, parse_size
+
+        files_config = self.files_config if isinstance(self.files_config, dict) else {}
+        rules = []
+
+        for catalog_entry in FILES_RULES:
+            if catalog_entry.check == "file_size":
+                max_size = parse_size(files_config.get("max_size"))
+                if max_size is None:
+                    continue
+                rendered = format_size(max_size)
+                rules.append(
+                    ValidationRule(
+                        check=catalog_entry.check,
+                        error=(catalog_entry.error or "").format(max_size=rendered),
+                        suggest=(catalog_entry.suggest or "").format(max_size=rendered),
+                        value=max_size,
+                    )
+                )
+            elif catalog_entry.check == "file_pattern":
+                raw = files_config.get("prohibited_patterns")
+                patterns = (
+                    [p for p in raw if isinstance(p, str) and p.strip()]
+                    if isinstance(raw, list)
+                    else []
+                )
+                if not patterns:
+                    continue
+                rules.append(
+                    ValidationRule(
+                        check=catalog_entry.check,
+                        error=catalog_entry.error,
+                        suggest=catalog_entry.suggest,
+                        value=patterns,
+                    )
+                )
+            elif catalog_entry.check == "path_length":
+                max_len = files_config.get("max_path_length")
+                if isinstance(max_len, bool) or not isinstance(max_len, int):
+                    continue
+                if max_len <= 0:
+                    continue
+                rules.append(
+                    ValidationRule(
+                        check=catalog_entry.check,
+                        error=(catalog_entry.error or "").format(max_len=max_len),
+                        suggest=(catalog_entry.suggest or "").format(max_len=max_len),
+                        value=max_len,
+                    )
+                )
 
         return rules
 

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -131,58 +131,73 @@ class RuleBuilder:
         non-table section, an unparsable size, a non-list pattern set)
         disable the rule rather than failing every commit.
         """
+        files_config = self.files_config if isinstance(self.files_config, dict) else {}
+        builders = {
+            "file_size": self._build_file_size_rule,
+            "file_pattern": self._build_file_pattern_rule,
+            "path_length": self._build_path_length_rule,
+        }
+
+        rules = []
+        for catalog_entry in FILES_RULES:
+            builder = builders.get(catalog_entry.check)
+            rule = builder(catalog_entry, files_config) if builder else None
+            if rule:
+                rules.append(rule)
+        return rules
+
+    @staticmethod
+    def _build_file_size_rule(
+        catalog_entry: RuleCatalogEntry, files_config: dict[str, Any]
+    ) -> ValidationRule | None:
+        """Build the file size rule when max_size parses to a usable limit."""
         from commit_check.util import format_size, parse_size
 
-        files_config = self.files_config if isinstance(self.files_config, dict) else {}
-        rules = []
+        max_size = parse_size(files_config.get("max_size"))
+        if max_size is None:
+            return None
+        rendered = format_size(max_size)
+        return ValidationRule(
+            check=catalog_entry.check,
+            error=(catalog_entry.error or "").format(max_size=rendered),
+            suggest=(catalog_entry.suggest or "").format(max_size=rendered),
+            value=max_size,
+        )
 
-        for catalog_entry in FILES_RULES:
-            if catalog_entry.check == "file_size":
-                max_size = parse_size(files_config.get("max_size"))
-                if max_size is None:
-                    continue
-                rendered = format_size(max_size)
-                rules.append(
-                    ValidationRule(
-                        check=catalog_entry.check,
-                        error=(catalog_entry.error or "").format(max_size=rendered),
-                        suggest=(catalog_entry.suggest or "").format(max_size=rendered),
-                        value=max_size,
-                    )
-                )
-            elif catalog_entry.check == "file_pattern":
-                raw = files_config.get("prohibited_patterns")
-                patterns = (
-                    [p for p in raw if isinstance(p, str) and p.strip()]
-                    if isinstance(raw, list)
-                    else []
-                )
-                if not patterns:
-                    continue
-                rules.append(
-                    ValidationRule(
-                        check=catalog_entry.check,
-                        error=catalog_entry.error,
-                        suggest=catalog_entry.suggest,
-                        value=patterns,
-                    )
-                )
-            elif catalog_entry.check == "path_length":
-                max_len = files_config.get("max_path_length")
-                if isinstance(max_len, bool) or not isinstance(max_len, int):
-                    continue
-                if max_len <= 0:
-                    continue
-                rules.append(
-                    ValidationRule(
-                        check=catalog_entry.check,
-                        error=(catalog_entry.error or "").format(max_len=max_len),
-                        suggest=(catalog_entry.suggest or "").format(max_len=max_len),
-                        value=max_len,
-                    )
-                )
+    @staticmethod
+    def _build_file_pattern_rule(
+        catalog_entry: RuleCatalogEntry, files_config: dict[str, Any]
+    ) -> ValidationRule | None:
+        """Build the prohibited-pattern rule from the usable list entries."""
+        raw = files_config.get("prohibited_patterns")
+        patterns = (
+            [p for p in raw if isinstance(p, str) and p.strip()]
+            if isinstance(raw, list)
+            else []
+        )
+        if not patterns:
+            return None
+        return ValidationRule(
+            check=catalog_entry.check,
+            error=catalog_entry.error,
+            suggest=catalog_entry.suggest,
+            value=patterns,
+        )
 
-        return rules
+    @staticmethod
+    def _build_path_length_rule(
+        catalog_entry: RuleCatalogEntry, files_config: dict[str, Any]
+    ) -> ValidationRule | None:
+        """Build the path length rule when max_path_length is a positive int."""
+        max_len = files_config.get("max_path_length")
+        if isinstance(max_len, bool) or not isinstance(max_len, int) or max_len <= 0:
+            return None
+        return ValidationRule(
+            check=catalog_entry.check,
+            error=(catalog_entry.error or "").format(max_len=max_len),
+            suggest=(catalog_entry.suggest or "").format(max_len=max_len),
+            value=max_len,
+        )
 
     def _build_tag_rules(self) -> list[ValidationRule]:
         """Build tag-related validation rules.

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -10,7 +10,7 @@ ID ranges
 ``CC0xx``  Commit message rules
 ``CC1xx``  Author (name / email) rules
 ``CC2xx``  Branch rules
-``CC3xx``  Push rules
+``CC3xx``  Push and file rules
 ``CC4xx``  Tag rules
 =========  ==================================
 
@@ -189,6 +189,32 @@ PUSH_RULES = [
     ),
 ]
 
+# File rules: metadata about the files a commit touches (path, size) —
+# deliberately never their contents.
+FILES_RULES = [
+    RuleCatalogEntry(
+        rule_id="CC302",
+        check="file_size",
+        regex=None,
+        error="File exceeds the maximum size of {max_size}",
+        suggest="Keep files under {max_size}, or store large assets outside git (e.g. Git LFS); raise max_size in the [files] config section if the limit is wrong",
+    ),
+    RuleCatalogEntry(
+        rule_id="CC303",
+        check="file_pattern",
+        regex=None,
+        error="File path matches a prohibited pattern",
+        suggest="Remove the file from the commit (secrets already committed need their credentials rotated), or adjust prohibited_patterns in the [files] config section",
+    ),
+    RuleCatalogEntry(
+        rule_id="CC304",
+        check="path_length",
+        regex=None,
+        error="File path exceeds {max_len} characters",
+        suggest="Shorten the path to {max_len} characters or fewer",
+    ),
+]
+
 # Branch rules
 BRANCH_RULES = [
     RuleCatalogEntry(
@@ -228,7 +254,7 @@ TAG_RULES = [
 #: All catalog entries that represent a user-facing, documented rule.
 ALL_RULES = [
     entry
-    for entry in (*COMMIT_RULES, *BRANCH_RULES, *PUSH_RULES, *TAG_RULES)
+    for entry in (*COMMIT_RULES, *BRANCH_RULES, *PUSH_RULES, *FILES_RULES, *TAG_RULES)
     if entry.rule_id is not None
 ]
 

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -109,6 +109,114 @@ def get_tags_at(rev: str = "HEAD") -> list[str]:
     return tags
 
 
+_SIZE_UNITS = {"B": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3}
+
+
+def parse_size(value) -> int | None:
+    """Parse a human file size into bytes.
+
+    Accepts an ``int`` (bytes) or a string with an optional binary unit
+    suffix — ``"5MB"``, ``"500 KB"``, ``"1gb"``, ``"12345"`` — where
+    ``KB``/``MB``/``GB`` are powers of 1024.
+
+    :param value: The configured size.
+    :returns: The size in bytes, or ``None`` when the value is empty,
+        non-positive, or not a size at all — an unusable limit disables the
+        rule rather than failing every file.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip().upper().replace(" ", "")
+    if not text:
+        return None
+    for suffix, factor in sorted(_SIZE_UNITS.items(), key=lambda kv: -len(kv[0])):
+        if text.endswith(suffix):
+            number = text[: -len(suffix)]
+            break
+    else:
+        number, factor = text, 1
+    try:
+        size = int(float(number) * factor)
+    except ValueError:
+        return None
+    return size if size > 0 else None
+
+
+def format_size(size: int) -> str:
+    """Render a byte count with the largest fitting binary unit."""
+    for suffix in ("GB", "MB", "KB"):
+        factor = _SIZE_UNITS[suffix]
+        if size >= factor:
+            value = size / factor
+            text = f"{value:.1f}".rstrip("0").rstrip(".")
+            return f"{text} {suffix}"
+    return f"{size} B"
+
+
+def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
+    """List the files a commit touches, with their sizes at that commit.
+
+    Deletions are excluded — removing a file adds nothing to police — and so
+    are non-blob entries such as submodules. Sizes are the blob sizes as of
+    the commit, not whatever the working tree holds now.
+
+    :param rev: Revision whose changed files to list, ``HEAD`` by default.
+    :returns: ``(path, size_in_bytes)`` pairs, empty when the revision does
+        not resolve or touches nothing.
+    """
+    diff = subprocess.run(
+        [
+            "git",
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "--root",
+            "--diff-filter=d",
+            "-r",
+            "-z",
+            rev,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    if diff.returncode != 0:
+        return []
+    paths = [p for p in diff.stdout.split("\0") if p]
+    if not paths:
+        return []
+
+    files: list[tuple[str, int]] = []
+    # Batch the paths: a commit can touch more files than one command line
+    # holds.
+    for start in range(0, len(paths), 500):
+        # :(literal) keeps a path containing glob characters a path, not a
+        # pathspec pattern.
+        batch = [f":(literal){p}" for p in paths[start : start + 500]]
+        tree = subprocess.run(
+            ["git", "ls-tree", "-r", "-l", "-z", rev, "--", *batch],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+        )
+        if tree.returncode != 0:
+            continue
+        for entry in tree.stdout.split("\0"):
+            if "\t" not in entry:
+                continue
+            header, path = entry.split("\t", 1)
+            fields = header.split()
+            # <mode> <type> <sha> <size>; size is "-" for non-blob entries.
+            if len(fields) == 4 and fields[1] == "blob" and fields[3].isdigit():
+                files.append((path, int(fields[3])))
+    return files
+
+
 def get_upstream_branch() -> str:
     """Return the configured upstream ref for the current branch.
 

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -142,7 +142,7 @@ def parse_size(value) -> int | None:
         number, factor = text, 1
     try:
         size = int(float(number) * factor)
-    except ValueError:
+    except (ValueError, OverflowError):
         return None
     return size if size > 0 else None
 

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -158,6 +158,45 @@ def format_size(size: int) -> str:
     return f"{size} B"
 
 
+#: Cap on the characters of pathspec arguments handed to one ``git ls-tree``.
+#: Windows refuses a command line over 32 KiB, and a batch that overflows
+#: would drop the files it carried from the checked set.
+_LS_TREE_ARG_BUDGET = 24_000
+
+#: Cap on the number of pathspecs in one batch, independent of their length.
+_LS_TREE_BATCH = 500
+
+
+def _pathspec_batches(paths: list[str]) -> list[list[str]]:
+    """Group paths into ``git ls-tree`` pathspec batches.
+
+    Batches are bounded by both count and total length: a commit can touch
+    more files than one command line holds, and a few very long paths can
+    overflow it well before the count cap.
+
+    ``:(top,literal)`` keeps each path a literal path anchored at the
+    repository root — literal because a file name may contain glob
+    characters, top because pathspecs are otherwise read relative to the
+    current directory, which would match nothing when commit-check runs
+    from a subdirectory.
+    """
+    batches: list[list[str]] = []
+    batch: list[str] = []
+    budget = 0
+    for path in paths:
+        spec = f":(top,literal){path}"
+        if batch and (
+            len(batch) >= _LS_TREE_BATCH or budget + len(spec) > _LS_TREE_ARG_BUDGET
+        ):
+            batches.append(batch)
+            batch, budget = [], 0
+        batch.append(spec)
+        budget += len(spec) + 1
+    if batch:
+        batches.append(batch)
+    return batches
+
+
 def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
     """List the files a commit touches, with their sizes at that commit.
 
@@ -165,9 +204,14 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
     are non-blob entries such as submodules. Sizes are the blob sizes as of
     the commit, not whatever the working tree holds now.
 
+    For a merge commit the files are those the merge brings onto the branch
+    it lands on (the diff against its first parent). Without that a merge
+    would report no files at all, and a prohibited file arriving through a
+    merge — the moment CI checks a pull request — would pass unexamined.
+
     :param rev: Revision whose changed files to list, ``HEAD`` by default.
     :returns: ``(path, size_in_bytes)`` pairs, empty when the revision does
-        not resolve or touches nothing.
+        not resolve, touches nothing, or cannot be measured.
     """
     diff = subprocess.run(
         [
@@ -176,6 +220,10 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
             "--no-commit-id",
             "--name-only",
             "--root",
+            # Diff merges against their first parent instead of emitting
+            # nothing for them.
+            "-m",
+            "--first-parent",
             "--diff-filter=d",
             "-r",
             "-z",
@@ -192,20 +240,24 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
         return []
 
     files: list[tuple[str, int]] = []
-    # Batch the paths: a commit can touch more files than one command line
-    # holds.
-    for start in range(0, len(paths), 500):
-        # :(literal) keeps a path containing glob characters a path, not a
-        # pathspec pattern.
-        batch = [f":(literal){p}" for p in paths[start : start + 500]]
-        tree = subprocess.run(
-            ["git", "ls-tree", "-r", "-l", "-z", rev, "--", *batch],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-        )
+    for batch in _pathspec_batches(paths):
+        try:
+            tree = subprocess.run(
+                ["git", "ls-tree", "-r", "-l", "-z", "--full-tree", rev, "--", *batch],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+            )
+        except OSError:
+            # An unrunnable command line (length limits, missing git) leaves
+            # this batch unmeasured; see below for why that ends the lookup.
+            return []
         if tree.returncode != 0:
-            continue
+            # A partial result would under-report: the rules would pass on
+            # the files that were measured while the rest went unchecked.
+            # Report nothing instead, which the validators surface as a skip
+            # ("not validated") rather than a silent pass.
+            return []
         for entry in tree.stdout.split("\0"):
             if "\t" not in entry:
                 continue
@@ -215,6 +267,36 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
             if len(fields) == 4 and fields[1] == "blob" and fields[3].isdigit():
                 files.append((path, int(fields[3])))
     return files
+
+
+def get_push_commits(local_sha: str, remote_sha: str) -> list[str]:
+    """List the commits a push introduces, newest first.
+
+    A pre-push hook is told both ends of what is being pushed. Checking only
+    the tip would let anything committed earlier in the same push through,
+    so the range the remote does not have yet is what gets checked.
+
+    :param local_sha: The sha being pushed.
+    :param remote_sha: What the remote currently has, all zeroes for a new ref.
+    :returns: The commit shas in the pushed range; the tip alone if the range
+        cannot be computed.
+    """
+    if set(remote_sha) == {"0"}:
+        # A new ref carries every commit the remote cannot already reach.
+        args = [local_sha, "--not", "--remotes"]
+    else:
+        args = [f"{remote_sha}..{local_sha}"]
+    result = subprocess.run(
+        ["git", "rev-list", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    if result.returncode != 0:
+        # An unresolvable range (a remote sha this clone lacks, say) still
+        # leaves the tip worth checking.
+        return [local_sha]
+    return [line for line in result.stdout.split() if line]
 
 
 def get_upstream_branch() -> str:

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -223,29 +223,41 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
     the commit, not whatever the working tree holds now.
 
     For a merge commit the files are those the merge brings onto the branch
-    it lands on (the diff against its first parent). Without that a merge
-    would report no files at all, and a prohibited file arriving through a
-    merge — the moment CI checks a pull request — would pass unexamined.
+    it lands on: the diff against its first parent. A merge is diffed
+    explicitly against that parent rather than with ``-m``, which emits a
+    diff per parent — that would both repeat a path and drag in files the
+    *other* parent already carried, failing a merge over a file it never
+    introduced.
 
     :param rev: Revision whose changed files to list, ``HEAD`` by default.
     :returns: ``(path, size_in_bytes)`` pairs, empty when the revision does
         not resolve, touches nothing, or cannot be measured.
     """
+    # "<sha> <parent>..." — names the first parent and says whether there is
+    # one, in a single call that also rejects an unresolvable revision.
+    lineage = subprocess.run(
+        ["git", "rev-list", "--parents", "-n", "1", rev],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        encoding="utf-8",
+    )
+    if lineage.returncode != 0:
+        return []
+    parents = lineage.stdout.split()[1:]
+    # A root commit has nothing to diff against, so --root compares it to
+    # the empty tree; anything else is a two-tree diff against parent one.
+    scope = ["--root", rev] if not parents else [parents[0], rev]
+
     diff = subprocess.run(
         [
             "git",
             "diff-tree",
             "--no-commit-id",
             "--name-only",
-            "--root",
-            # Diff merges against their first parent instead of emitting
-            # nothing for them.
-            "-m",
-            "--first-parent",
             "--diff-filter=d",
             "-r",
             "-z",
-            rev,
+            *scope,
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -197,6 +197,24 @@ def _pathspec_batches(paths: list[str]) -> list[list[str]]:
     return batches
 
 
+def _blob_sizes(output: str) -> list[tuple[str, int]]:
+    """Parse ``git ls-tree -l -z`` output into ``(path, size)`` pairs.
+
+    Non-blob entries such as submodules carry ``-`` where a size belongs
+    and are left out.
+    """
+    files: list[tuple[str, int]] = []
+    for entry in output.split("\0"):
+        if "\t" not in entry:
+            continue
+        header, path = entry.split("\t", 1)
+        # <mode> <type> <sha> <size>
+        fields = header.split()
+        if len(fields) == 4 and fields[1] == "blob" and fields[3].isdigit():
+            files.append((path, int(fields[3])))
+    return files
+
+
 def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
     """List the files a commit touches, with their sizes at that commit.
 
@@ -258,14 +276,7 @@ def get_commit_files(rev: str = "HEAD") -> list[tuple[str, int]]:
             # Report nothing instead, which the validators surface as a skip
             # ("not validated") rather than a silent pass.
             return []
-        for entry in tree.stdout.split("\0"):
-            if "\t" not in entry:
-                continue
-            header, path = entry.split("\t", 1)
-            fields = header.split()
-            # <mode> <type> <sha> <size>; size is "-" for non-blob entries.
-            if len(fields) == 4 and fields[1] == "blob" and fields[3].isdigit():
-                files.append((path, int(fields[3])))
+        files.extend(_blob_sizes(tree.stdout))
     return files
 
 

--- a/tests/config_merger_test.py
+++ b/tests/config_merger_test.py
@@ -397,3 +397,32 @@ class TestTagConfig:
         monkeypatch.setenv("CCHK_TAG_REGEX", r"^rel-\d+$")
         config = ConfigMerger.parse_env_vars()
         assert config["tag"]["regex"] == r"^rel-\d+$"
+
+
+class TestFilesConfig:
+    """Tests for the [files] section across config sources."""
+
+    @pytest.mark.benchmark
+    def test_default_config_has_files_section_off(self):
+        from commit_check.config_merger import get_default_config
+
+        config = get_default_config()
+        assert config["files"] == {
+            "max_size": "",
+            "prohibited_patterns": [],
+            "max_path_length": 0,
+        }
+
+    @pytest.mark.benchmark
+    def test_env_vars_reach_files_section(self, monkeypatch):
+        from commit_check.config_merger import ConfigMerger
+
+        monkeypatch.setenv("CCHK_FILES_MAX_SIZE", "5MB")
+        monkeypatch.setenv("CCHK_FILES_PROHIBITED_PATTERNS", "*.pem,.env")
+        monkeypatch.setenv("CCHK_FILES_MAX_PATH_LENGTH", "200")
+        config = ConfigMerger.parse_env_vars()
+        assert config["files"] == {
+            "max_size": "5MB",
+            "prohibited_patterns": ["*.pem", ".env"],
+            "max_path_length": 200,
+        }

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2971,3 +2971,20 @@ class TestFilesValidator:
         validator = FilesValidator(rule)
         validator.validate(ValidationContext(rev="abc123"))
         mock_files.assert_called_once_with("abc123")
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_path_length_within_limit_passes(self, mock_files):
+        mock_files.return_value = [("short/path.txt", 10)]
+        rule = ValidationRule(check="path_length", value=40)
+        validator = FilesValidator(rule)
+        assert validator.validate(ValidationContext()) == ValidationResult.PASS
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_unknown_check_name_passes_defensively(self, mock_files):
+        """A rule this validator does not know cannot fail a commit."""
+        mock_files.return_value = [("a.txt", 10)]
+        rule = ValidationRule(check="not_a_files_check", value=1)
+        validator = FilesValidator(rule)
+        assert validator.validate(ValidationContext()) == ValidationResult.PASS

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2988,3 +2988,51 @@ class TestFilesValidator:
         rule = ValidationRule(check="not_a_files_check", value=1)
         validator = FilesValidator(rule)
         assert validator.validate(ValidationContext()) == ValidationResult.PASS
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_pre_push_stdin_validates_the_pushed_sha(self, mock_files):
+        """Pushing another local ref checks that ref's tip, not HEAD."""
+        mock_files.return_value = [("a.txt", 10)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        stdin = "refs/heads/topic abc123 refs/heads/topic def456\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.PASS
+        mock_files.assert_called_once_with("abc123")
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_pre_push_stdin_validates_every_pushed_ref(self, mock_files):
+        """A push of several refs checks each pushed tip."""
+        mock_files.return_value = [("a.txt", 10)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        stdin = (
+            "refs/heads/one aaa111 refs/heads/one bbb222\n"
+            "refs/heads/two ccc333 refs/heads/two ddd444\n"
+        )
+        validator.validate(ValidationContext(stdin_text=stdin))
+        assert [c.args[0] for c in mock_files.call_args_list] == ["aaa111", "ccc333"]
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_pre_push_deletion_only_skips(self, mock_files):
+        """Deleting a ref removes content rather than adding it."""
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        zero = "0" * 40
+        stdin = f"(delete) {zero} refs/heads/gone abc123\n"
+        result = validator.validate(ValidationContext(stdin_text=stdin))
+        assert result == ValidationResult.SKIP
+        mock_files.assert_not_called()
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_non_push_stdin_falls_back_to_rev(self, mock_files):
+        """Stdin meant for another check does not redirect the files check."""
+        mock_files.return_value = [("a.txt", 10)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        validator.validate(ValidationContext(stdin_text="feature/branch-name"))
+        mock_files.assert_called_once_with("HEAD")

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2977,6 +2977,20 @@ class TestFilesValidator:
 
     @patch("commit_check.engine.get_commit_files")
     @pytest.mark.benchmark
+    def test_pattern_matching_is_case_sensitive_everywhere(self, mock_files):
+        """One config must not mean two policies across platforms.
+
+        fnmatch() folds case via os.path.normcase, so the same rule would
+        catch KEY.PEM on Windows and miss it on Linux.
+        """
+        mock_files.return_value = [("secrets/KEY.PEM", 10)]
+        rule = ValidationRule(check="file_pattern", value=["*.pem"])
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.PASS
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
     def test_file_size_within_limit_passes(self, mock_files):
         mock_files.return_value = [("a.txt", 100), ("b.bin", 900)]
         rule = ValidationRule(check="file_size", value=1024)

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2888,6 +2888,73 @@ class TestTagValidator:
 
 
 class TestFilesValidator:
+    @patch("commit_check.engine.get_push_commits")
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_pre_push_checks_the_whole_pushed_range(self, mock_files, mock_range):
+        """Every commit in the push is checked, not just the ref's tip.
+
+        A file added by an earlier commit of a multi-commit push would
+        otherwise sail through, which is most of what the hook is for.
+        """
+        mock_range.return_value = ["tip", "earlier"]
+        mock_files.side_effect = lambda rev: {
+            "tip": [("small.txt", 3)],
+            "earlier": [("leaked.pem", 10)],
+        }[rev]
+        rule = ValidationRule(check="file_pattern", value=["*.pem"])
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        context = ValidationContext(
+            stdin_text="refs/heads/main aaa refs/heads/main bbb"
+        )
+        assert validator.validate(context) == ValidationResult.FAIL
+        assert validator._checked_value == "leaked.pem (pattern *.pem)"
+        mock_range.assert_called_once_with("aaa", "bbb")
+
+    @patch("commit_check.engine.get_push_commits")
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_pushed_tags_are_not_re_validated(self, mock_files, mock_range):
+        """A tag names history already pushed; CC401 polices tag names."""
+        rule = ValidationRule(check="file_pattern", value=["*.pem"])
+        validator = FilesValidator(rule)
+        context = ValidationContext(
+            stdin_text="refs/tags/v1.0.0 aaa refs/tags/v1.0.0 bbb"
+        )
+        assert validator.validate(context) == ValidationResult.SKIP
+        mock_range.assert_not_called()
+        mock_files.assert_not_called()
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_files_are_read_once_per_revision(self, mock_files):
+        """The three file rules share one lookup instead of tripling it."""
+        mock_files.return_value = [("a.txt", 10)]
+        context = ValidationContext()
+        for check, value in (
+            ("file_size", 1024),
+            ("file_pattern", ["*.pem"]),
+            ("path_length", 250),
+        ):
+            FilesValidator(ValidationRule(check=check, value=value)).validate(context)
+        assert mock_files.call_count == 1
+
+    @patch("commit_check.engine.get_push_commits")
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_a_file_touched_twice_is_one_offender(self, mock_files, mock_range):
+        mock_range.return_value = ["tip", "earlier"]
+        mock_files.return_value = [("big.bin", 5 * 1024**2)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        context = ValidationContext(
+            stdin_text="refs/heads/main aaa refs/heads/main bbb"
+        )
+        assert validator.validate(context) == ValidationResult.FAIL
+        assert validator._checked_value == "big.bin (5 MB)"
+
     @patch("commit_check.engine.get_commit_files")
     @pytest.mark.benchmark
     def test_file_size_within_limit_passes(self, mock_files):

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -13,6 +13,7 @@ from commit_check.engine import (
     CommitMessageValidator,
     BranchValidator,
     TagValidator,
+    FilesValidator,
     AuthorValidator,
     CommitTypeValidator,
     SubjectImperativeValidator,
@@ -2884,3 +2885,89 @@ class TestTagValidator:
         stdin = f"(delete) {zero} refs/tags/bad_tag def456\n"
         result = validator.validate(ValidationContext(stdin_text=stdin))
         assert result == ValidationResult.SKIP
+
+
+class TestFilesValidator:
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_size_within_limit_passes(self, mock_files):
+        mock_files.return_value = [("a.txt", 100), ("b.bin", 900)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        assert validator.validate(ValidationContext()) == ValidationResult.PASS
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_size_over_limit_fails_naming_the_file(self, mock_files):
+        mock_files.return_value = [("a.txt", 100), ("big.bin", 5 * 1024**2)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.FAIL
+        assert validator._checked_value == "big.bin (5 MB)"
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_size_counts_extra_offenders(self, mock_files):
+        mock_files.return_value = [("a.bin", 2048), ("b.bin", 4096), ("c.bin", 8192)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.FAIL
+        assert validator._checked_value == "a.bin (2 KB) (+2 more)"
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_pattern_matches_basename_at_any_depth(self, mock_files):
+        mock_files.return_value = [("secrets/server.pem", 10)]
+        rule = ValidationRule(check="file_pattern", value=["*.pem"])
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.FAIL
+        assert validator._checked_value == "secrets/server.pem (pattern *.pem)"
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_pattern_matches_full_path(self, mock_files):
+        mock_files.return_value = [("secrets/token.txt", 10)]
+        rule = ValidationRule(check="file_pattern", value=["secrets/*"])
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.FAIL
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_file_pattern_clean_commit_passes(self, mock_files):
+        mock_files.return_value = [("src/app.py", 10), ("README.md", 5)]
+        rule = ValidationRule(check="file_pattern", value=["*.pem", ".env"])
+        validator = FilesValidator(rule)
+        assert validator.validate(ValidationContext()) == ValidationResult.PASS
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_path_length_over_limit_fails(self, mock_files):
+        long_path = "a/" * 30 + "file.txt"
+        mock_files.return_value = [(long_path, 10)]
+        rule = ValidationRule(check="path_length", value=40)
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        assert validator.validate(ValidationContext()) == ValidationResult.FAIL
+        assert f"({len(long_path)} characters)" in validator._checked_value
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_no_touched_files_skips(self, mock_files):
+        """A deletion-only commit or unresolvable revision has nothing to police."""
+        mock_files.return_value = []
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        assert validator.validate(ValidationContext()) == ValidationResult.SKIP
+
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_rev_is_forwarded(self, mock_files):
+        mock_files.return_value = [("a.txt", 1)]
+        rule = ValidationRule(check="file_size", value=1024)
+        validator = FilesValidator(rule)
+        validator.validate(ValidationContext(rev="abc123"))
+        mock_files.assert_called_once_with("abc123")

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -2915,16 +2915,36 @@ class TestFilesValidator:
     @patch("commit_check.engine.get_push_commits")
     @patch("commit_check.engine.get_commit_files")
     @pytest.mark.benchmark
-    def test_pushed_tags_are_not_re_validated(self, mock_files, mock_range):
-        """A tag names history already pushed; CC401 polices tag names."""
+    def test_tag_on_pushed_history_adds_nothing(self, mock_files, mock_range):
+        """A tag over commits the remote has resolves to an empty range."""
+        mock_range.return_value = []
         rule = ValidationRule(check="file_pattern", value=["*.pem"])
         validator = FilesValidator(rule)
         context = ValidationContext(
             stdin_text="refs/tags/v1.0.0 aaa refs/tags/v1.0.0 bbb"
         )
         assert validator.validate(context) == ValidationResult.SKIP
-        mock_range.assert_not_called()
         mock_files.assert_not_called()
+
+    @patch("commit_check.engine.get_push_commits")
+    @patch("commit_check.engine.get_commit_files")
+    @pytest.mark.benchmark
+    def test_tag_carrying_a_new_commit_is_checked(self, mock_files, mock_range):
+        """A tag can be the only thing carrying a commit to the remote.
+
+        Skipping tag refs outright let a prohibited file reach the remote
+        whenever no pushed branch contained its commit.
+        """
+        mock_range.return_value = ["tagged"]
+        mock_files.return_value = [("leaked.pem", 12)]
+        rule = ValidationRule(check="file_pattern", value=["*.pem"])
+        validator = FilesValidator(rule)
+        validator._suppress_output = True
+        context = ValidationContext(
+            stdin_text="refs/tags/v1.0.0 aaa refs/tags/v1.0.0 bbb"
+        )
+        assert validator.validate(context) == ValidationResult.FAIL
+        assert validator._checked_value == "leaked.pem (pattern *.pem)"
 
     @patch("commit_check.engine.get_commit_files")
     @pytest.mark.benchmark

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1240,3 +1240,49 @@ class TestTagFlag:
         args = _get_parser().parse_args(["-t", "--tag-regex", r"^rel-\d+$"])
         config = ConfigMerger.parse_cli_args(args)
         assert config["tag"]["regex"] == r"^rel-\d+$"
+
+
+class TestFilesFlag:
+    """Tests for the -f/--files check type."""
+
+    def test_files_flag_in_help(self, capfd, monkeypatch):
+        monkeypatch.setattr("sys.argv", [CMD, "--help"])
+        with pytest.raises(SystemExit):
+            main()
+        out, _ = capfd.readouterr()
+        assert "--files" in out
+        assert "--files-max-size" in out
+        assert "--files-prohibited-patterns" in out
+        assert "--files-max-path-length" in out
+
+    def test_files_in_requested_checks(self):
+        from commit_check.main import _get_parser, _get_requested_checks
+
+        args = _get_parser().parse_args(["-f"])
+        assert _get_requested_checks(args) == [
+            "file_size",
+            "file_pattern",
+            "path_length",
+        ]
+
+    def test_files_cli_options_reach_config(self):
+        from commit_check.main import _get_parser
+        from commit_check.config_merger import ConfigMerger
+
+        args = _get_parser().parse_args(
+            [
+                "-f",
+                "--files-max-size",
+                "5MB",
+                "--files-prohibited-patterns",
+                "*.pem,.env",
+                "--files-max-path-length",
+                "200",
+            ]
+        )
+        config = ConfigMerger.parse_cli_args(args)
+        assert config["files"] == {
+            "max_size": "5MB",
+            "prohibited_patterns": ["*.pem", ".env"],
+            "max_path_length": 200,
+        }

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1294,3 +1294,40 @@ class TestFilesFlag:
         assert main() == 0
         _, err = capfd.readouterr()
         assert "nothing is configured in the [files] section" in err
+
+    def test_files_pre_commit_env_validates_pushed_sha(
+        self, mocker, monkeypatch, tmp_path, capfd
+    ):
+        """Under the pre-commit framework --files checks the pushed sha, not HEAD."""
+        git = lambda *a: subprocess.run(  # noqa: E731
+            ["git", *a], cwd=tmp_path, capture_output=True, encoding="utf-8"
+        )
+        git("init", "-q")
+        git("config", "user.name", "T")
+        git("config", "user.email", "t@example.com")
+        (tmp_path / "cchk.toml").write_text('[files]\nmax_size = "1KB"\n')
+        git("add", "cchk.toml")
+        git("commit", "-qm", "feat: config")
+        (tmp_path / "big.bin").write_bytes(b"x" * 4096)
+        git("add", "big.bin")
+        git("commit", "-qm", "feat: big file")
+        pushed = git("rev-parse", "HEAD").stdout.strip()
+        git("rm", "-q", "big.bin")
+        git("commit", "-qm", "chore: remove big file")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("sys.argv", [CMD, "--files"])
+        # The framework consumed git's stdin; only the environment remains.
+        mocker.patch.object(StdinReader, "read_piped_input", return_value=None)
+        monkeypatch.setenv("PRE_COMMIT_LOCAL_BRANCH", "refs/heads/topic")
+        monkeypatch.setenv("PRE_COMMIT_REMOTE_BRANCH", "refs/heads/topic")
+        monkeypatch.setenv("PRE_COMMIT_TO_REF", pushed)
+        monkeypatch.setenv("PRE_COMMIT_FROM_REF", "a" * 40)
+        monkeypatch.delenv("PRE_COMMIT_REMOTE_NAME", raising=False)
+        monkeypatch.delenv("PRE_COMMIT_REMOTE_URL", raising=False)
+
+        # HEAD only deletes the file, so a HEAD check would skip; failing
+        # proves the pushed sha was validated.
+        assert main() == 1
+        out, _ = capfd.readouterr()
+        assert "big.bin" in out

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1286,3 +1286,11 @@ class TestFilesFlag:
             "prohibited_patterns": ["*.pem", ".env"],
             "max_path_length": 200,
         }
+
+    def test_files_unconfigured_prints_hint(self, capfd, monkeypatch, tmp_path):
+        """--files with an empty [files] section says so instead of passing silently."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("sys.argv", [CMD, "--files"])
+        assert main() == 0
+        _, err = capfd.readouterr()
+        assert "nothing is configured in the [files] section" in err

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -556,6 +556,30 @@ class TestTagRules:
 
 class TestFilesRules:
     @pytest.mark.benchmark
+    def test_unusable_max_size_is_reported(self, capsys):
+        """A rejected value must not disable its rule in silence.
+
+        The "nothing configured" hint only fires when no file rule builds at
+        all, so a bad max_size alongside a good pattern list would otherwise
+        leave the size cap absent without a word.
+        """
+        builder = RuleBuilder(
+            {"files": {"max_size": "5M", "prohibited_patterns": ["*.pem"]}}
+        )
+        rules = builder.build_all_rules()
+        checks = [rule.check for rule in rules]
+        assert "file_size" not in checks
+        assert "file_pattern" in checks
+        err = capsys.readouterr().err
+        assert "max_size" in err and "5M" in err and "CC302" in err
+
+    @pytest.mark.benchmark
+    def test_unset_values_are_not_reported(self, capsys):
+        """Silence is right for a section that simply does not opt in."""
+        RuleBuilder({"files": {"max_size": "", "max_path_length": 0}}).build_all_rules()
+        assert capsys.readouterr().err == ""
+
+    @pytest.mark.benchmark
     def test_files_rules_off_by_default(self):
         """No [files] config, no file rules — all three are opt-in."""
         rules = RuleBuilder({}).build_all_rules()

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -571,7 +571,9 @@ class TestFilesRules:
         assert "file_size" not in checks
         assert "file_pattern" in checks
         err = capsys.readouterr().err
-        assert "max_size" in err and "5M" in err and "CC302" in err
+        assert "max_size" in err
+        assert "5M" in err
+        assert "CC302" in err
 
     @pytest.mark.benchmark
     def test_non_table_files_section_is_reported(self, capsys):
@@ -581,7 +583,8 @@ class TestFilesRules:
             r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
         ]
         err = capsys.readouterr().err
-        assert "must be a table" in err and "garbage" in err
+        assert "must be a table" in err
+        assert "garbage" in err
 
     @pytest.mark.benchmark
     def test_unset_values_are_not_reported(self, capsys):

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -552,3 +552,70 @@ class TestTagRules:
         builder = RuleBuilder({"tag": {"regex": 123}})
         tag_rule = next(r for r in builder.build_all_rules() if r.check == "tag")
         assert tag_rule.regex == DEFAULT_TAG_REGEX
+
+
+class TestFilesRules:
+    @pytest.mark.benchmark
+    def test_files_rules_off_by_default(self):
+        """No [files] config, no file rules — all three are opt-in."""
+        rules = RuleBuilder({}).build_all_rules()
+        assert not [
+            r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
+        ]
+
+    @pytest.mark.benchmark
+    def test_files_rules_built_from_config(self):
+        builder = RuleBuilder(
+            {
+                "files": {
+                    "max_size": "5MB",
+                    "prohibited_patterns": ["*.pem", ".env"],
+                    "max_path_length": 200,
+                }
+            }
+        )
+        rules = {r.check: r for r in builder.build_all_rules()}
+
+        assert rules["file_size"].rule_id == "CC302"
+        assert rules["file_size"].value == 5 * 1024**2
+        assert "5 MB" in rules["file_size"].error
+        assert rules["file_pattern"].rule_id == "CC303"
+        assert rules["file_pattern"].value == ["*.pem", ".env"]
+        assert rules["path_length"].rule_id == "CC304"
+        assert rules["path_length"].value == 200
+        assert "200" in rules["path_length"].error
+
+    @pytest.mark.benchmark
+    def test_files_rules_built_independently(self):
+        """Each setting stands alone — configuring one enables only that one."""
+        rules = RuleBuilder({"files": {"max_size": 1024}}).build_all_rules()
+        checks = [
+            r.check
+            for r in rules
+            if r.check in ("file_size", "file_pattern", "path_length")
+        ]
+        assert checks == ["file_size"]
+
+    @pytest.mark.benchmark
+    def test_files_rules_malformed_values_disable(self):
+        """Unusable values disable a rule rather than failing every commit."""
+        builder = RuleBuilder(
+            {
+                "files": {
+                    "max_size": "not-a-size",
+                    "prohibited_patterns": "not-a-list",
+                    "max_path_length": True,
+                }
+            }
+        )
+        rules = builder.build_all_rules()
+        assert not [
+            r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
+        ]
+
+    @pytest.mark.benchmark
+    def test_files_non_mapping_section_disables(self):
+        rules = RuleBuilder({"files": "garbage"}).build_all_rules()
+        assert not [
+            r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
+        ]

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -574,6 +574,16 @@ class TestFilesRules:
         assert "max_size" in err and "5M" in err and "CC302" in err
 
     @pytest.mark.benchmark
+    def test_non_table_files_section_is_reported(self, capsys):
+        """A scalar [files] must not vanish into an empty section in silence."""
+        rules = RuleBuilder({"files": "garbage"}).build_all_rules()
+        assert not [
+            r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
+        ]
+        err = capsys.readouterr().err
+        assert "must be a table" in err and "garbage" in err
+
+    @pytest.mark.benchmark
     def test_unset_values_are_not_reported(self, capsys):
         """Silence is right for a section that simply does not opt in."""
         RuleBuilder({"files": {"max_size": "", "max_path_length": 0}}).build_all_rules()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1106,14 +1106,17 @@ class TestFormatSize:
         assert format_size(int(2.5 * 1024**3)) == "2.5 GB"
 
 
+def _run_git(tmp_path, *args):
+    """Run git in *tmp_path*, failing the test on a non-zero exit."""
+    result = subprocess.run(
+        ["git", *args], cwd=tmp_path, capture_output=True, encoding="utf-8"
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
 class TestGetCommitFiles:
-    @staticmethod
-    def _git(tmp_path, *args):
-        result = subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, encoding="utf-8"
-        )
-        assert result.returncode == 0, result.stderr
-        return result.stdout.strip()
+    _git = staticmethod(_run_git)
 
     def _repo(self, tmp_path):
         self._git(tmp_path, "init", "-q")
@@ -1275,13 +1278,7 @@ class TestPathspecBatches:
 
 
 class TestGetPushCommits:
-    @staticmethod
-    def _git(tmp_path, *args):
-        result = subprocess.run(
-            ["git", *args], cwd=tmp_path, capture_output=True, encoding="utf-8"
-        )
-        assert result.returncode == 0, result.stderr
-        return result.stdout.strip()
+    _git = staticmethod(_run_git)
 
     # No benchmark mark: real-git test, see above.
     def test_range_covers_every_pushed_commit(self, tmp_path, monkeypatch):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -35,6 +35,9 @@ from unittest.mock import MagicMock
 # String constants used across tests
 REFS_HEADS_MAIN = "refs/heads/main"
 USER_NAME_CONFIG = "user.name"
+USER_EMAIL_CONFIG = "user.email"
+TEST_EMAIL = "t@example.com"
+BASE_COMMIT_MSG = "chore: base"
 
 
 class TestUtil:
@@ -1116,13 +1119,24 @@ def _run_git(tmp_path, *args):
     return result.stdout.strip()
 
 
+def _init_git_repo(path, *init_args):
+    """Initialise a repo at *path* with an identity commits can be made under."""
+    _run_git(path, "init", "-q", *init_args)
+    _run_git(path, "config", USER_NAME_CONFIG, "T")
+    _run_git(path, "config", USER_EMAIL_CONFIG, TEST_EMAIL)
+
+
+def _commit_all(path, message):
+    """Stage everything under *path* and commit it."""
+    _run_git(path, "add", "-A")
+    _run_git(path, "commit", "-qm", message)
+
+
 class TestGetCommitFiles:
     _git = staticmethod(_run_git)
 
     def _repo(self, tmp_path):
-        self._git(tmp_path, "init", "-q")
-        self._git(tmp_path, "config", "user.name", "T")
-        self._git(tmp_path, "config", "user.email", "t@example.com")
+        _init_git_repo(tmp_path)
 
     # No benchmark mark: CodSpeed executes marked tests more than once against
     # the same tmp_path, and this test's mkdir/commit sequence only works on a
@@ -1285,12 +1299,9 @@ class TestGetPushCommits:
     def test_range_covers_every_pushed_commit(self, tmp_path, monkeypatch):
         from commit_check.util import get_push_commits
 
-        self._git(tmp_path, "init", "-q", "-b", "main")
-        self._git(tmp_path, "config", "user.name", "T")
-        self._git(tmp_path, "config", "user.email", "t@example.com")
+        _init_git_repo(tmp_path, "-b", "main")
         (tmp_path / "base.txt").write_text("base")
-        self._git(tmp_path, "add", "-A")
-        self._git(tmp_path, "commit", "-qm", "chore: base")
+        _commit_all(tmp_path, BASE_COMMIT_MSG)
         remote = self._git(tmp_path, "rev-parse", "HEAD")
         (tmp_path / "a.txt").write_text("a")
         self._git(tmp_path, "add", "-A")
@@ -1320,13 +1331,10 @@ class TestGetPushCommits:
         _run_git(tmp_path, "init", "-q", "--bare", str(remote))
         work = tmp_path / "work"
         work.mkdir()
-        _run_git(work, "init", "-q", "-b", "main")
-        _run_git(work, "config", "user.name", "T")
-        _run_git(work, "config", "user.email", "t@example.com")
+        _init_git_repo(work, "-b", "main")
         _run_git(work, "remote", "add", "origin", str(remote))
         (work / "base.txt").write_text("base")
-        _run_git(work, "add", "-A")
-        _run_git(work, "commit", "-qm", "chore: base")
+        _commit_all(work, BASE_COMMIT_MSG)
         _run_git(work, "push", "-q", "origin", "main")
 
         _run_git(work, "checkout", "-qb", "feature")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1171,3 +1171,12 @@ class TestGetCommitFiles:
         tree = mocker.Mock(returncode=128, stdout="", stderr="fatal: bad object")
         mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, tree])
         assert get_commit_files() == []
+
+
+class TestParseSizeOverflow:
+    @pytest.mark.benchmark
+    def test_infinite_sizes_are_unusable(self):
+        """inf-like values disable the rule instead of aborting the run."""
+        assert parse_size("inf") is None
+        assert parse_size("1e999MB") is None
+        assert parse_size("nan") is None

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1135,8 +1135,8 @@ def _commit_all(path, message):
 class TestGetCommitFiles:
     _git = staticmethod(_run_git)
 
-    def _repo(self, tmp_path):
-        _init_git_repo(tmp_path)
+    def _repo(self, tmp_path, *init_args):
+        _init_git_repo(tmp_path, *init_args)
 
     # No benchmark mark: CodSpeed executes marked tests more than once against
     # the same tmp_path, and this test's mkdir/commit sequence only works on a
@@ -1188,20 +1188,26 @@ class TestGetCommitFiles:
     @pytest.mark.benchmark
     def test_ls_tree_failure_yields_no_files(self, mocker):
         """A failing size lookup reports nothing rather than a partial set."""
+        lineage = mocker.Mock(returncode=0, stdout="sha parent\n", stderr="")
         diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
         tree = mocker.Mock(returncode=128, stdout="", stderr="fatal: bad object")
-        mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, tree])
+        mocker.patch(
+            "commit_check.util.subprocess.run", side_effect=[lineage, diff, tree]
+        )
         assert get_commit_files() == []
 
     @pytest.mark.benchmark
     def test_partial_batch_failure_reports_nothing(self, mocker):
         """One failed batch must not shrink the set the rules then pass on."""
+        lineage = mocker.Mock(returncode=0, stdout="sha parent\n", stderr="")
         diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
         ok = mocker.Mock(
             returncode=0, stdout="100644 blob abc     5\ta.txt\0", stderr=""
         )
         bad = mocker.Mock(returncode=128, stdout="", stderr="fatal")
-        mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, ok, bad])
+        mocker.patch(
+            "commit_check.util.subprocess.run", side_effect=[lineage, diff, ok, bad]
+        )
         mocker.patch(
             "commit_check.util._pathspec_batches",
             return_value=[[":(top,literal)a.txt"], [":(top,literal)b.txt"]],
@@ -1211,10 +1217,11 @@ class TestGetCommitFiles:
     @pytest.mark.benchmark
     def test_unrunnable_command_line_reports_nothing(self, mocker):
         """An OSError (Windows arg limits) is not an accidental pass."""
+        lineage = mocker.Mock(returncode=0, stdout="sha parent\n", stderr="")
         diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
         mocker.patch(
             "commit_check.util.subprocess.run",
-            side_effect=[diff, OSError("arg list too long")],
+            side_effect=[lineage, diff, OSError("arg list too long")],
         )
         assert get_commit_files() == []
 
@@ -1263,6 +1270,34 @@ class TestGetCommitFiles:
 
         monkeypatch.chdir(tmp_path)
         assert dict(get_commit_files()) == {"leaked.pem": 3}
+
+    # No benchmark mark: real-git test, see above.
+    def test_merge_excludes_what_the_other_parent_carried(self, tmp_path, monkeypatch):
+        """A merge is judged on what it brings in, not on the other side.
+
+        Diffing a merge against every parent (``-m``) reports files the
+        second parent already carried, so a merge would fail over a file it
+        never introduced -- and repeat any path both parents touched.
+        """
+        self._repo(tmp_path, "-b", "main")
+        (tmp_path / "shared.txt").write_text("1")
+        _commit_all(tmp_path, BASE_COMMIT_MSG)
+        self._git(tmp_path, "checkout", "-qb", "feature")
+        (tmp_path / "shared.txt").write_text("2")
+        _commit_all(tmp_path, "feat: edit shared")
+        self._git(tmp_path, "checkout", "-q", "main")
+        # main gains a file the feature branch never saw
+        (tmp_path / "already-on-main.bin").write_bytes(b"x" * 9000)
+        _commit_all(tmp_path, "feat: main only")
+        self._git(tmp_path, "merge", "--no-commit", "feature")
+        (tmp_path / "shared.txt").write_text("3")
+        _commit_all(tmp_path, "chore: merge feature")
+
+        monkeypatch.chdir(tmp_path)
+        files = get_commit_files()
+        paths = [path for path, _ in files]
+        assert paths == ["shared.txt"]
+        assert len(paths) == len(set(paths))
 
 
 class TestPathspecBatches:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1197,6 +1197,14 @@ class TestGetCommitFiles:
         assert get_commit_files() == []
 
     @pytest.mark.benchmark
+    def test_diff_failure_after_lineage_reports_nothing(self, mocker):
+        """A revision can resolve and still fail to diff (a damaged object)."""
+        lineage = mocker.Mock(returncode=0, stdout="sha parent\n", stderr="")
+        diff = mocker.Mock(returncode=128, stdout="", stderr="fatal: bad object")
+        mocker.patch("commit_check.util.subprocess.run", side_effect=[lineage, diff])
+        assert get_commit_files() == []
+
+    @pytest.mark.benchmark
     def test_partial_batch_failure_reports_nothing(self, mocker):
         """One failed batch must not shrink the set the rules then pass on."""
         lineage = mocker.Mock(returncode=0, stdout="sha parent\n", stderr="")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -7,6 +7,9 @@ import commit_check
 from commit_check import supports_color
 from commit_check.util import (
     get_tags_at,
+    get_commit_files,
+    parse_size,
+    format_size,
     fetch_remote_ref,
     fetch_upstream_ref,
     get_branch_name,
@@ -1075,3 +1078,88 @@ class TestGetTagsAt:
         monkeypatch.setenv("GITHUB_REF_TYPE", "tag")
         monkeypatch.setenv("GITHUB_REF_NAME", "v9.9.9")
         assert get_tags_at() == ["v1.0.0"]
+
+
+class TestParseSize:
+    @pytest.mark.benchmark
+    def test_parse_size_accepts_common_forms(self):
+        assert parse_size("5MB") == 5 * 1024**2
+        assert parse_size("500 KB") == 500 * 1024
+        assert parse_size("1gb") == 1024**3
+        assert parse_size("12345") == 12345
+        assert parse_size("1.5MB") == int(1.5 * 1024**2)
+        assert parse_size(4096) == 4096
+
+    @pytest.mark.benchmark
+    def test_parse_size_rejects_unusable_values(self):
+        """An unusable limit disables the rule rather than failing every file."""
+        for bad in ["", "  ", "abc", "MB", None, [], 0, -5, True, 1.5]:
+            assert parse_size(bad) is None, bad
+
+
+class TestFormatSize:
+    @pytest.mark.benchmark
+    def test_format_size_picks_largest_fitting_unit(self):
+        assert format_size(200) == "200 B"
+        assert format_size(1536) == "1.5 KB"
+        assert format_size(5 * 1024**2) == "5 MB"
+        assert format_size(int(2.5 * 1024**3)) == "2.5 GB"
+
+
+class TestGetCommitFiles:
+    @staticmethod
+    def _git(tmp_path, *args):
+        result = subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, encoding="utf-8"
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    def _repo(self, tmp_path):
+        self._git(tmp_path, "init", "-q")
+        self._git(tmp_path, "config", "user.name", "T")
+        self._git(tmp_path, "config", "user.email", "t@example.com")
+
+    @pytest.mark.benchmark
+    def test_lists_touched_files_with_sizes(self, tmp_path, monkeypatch):
+        self._repo(tmp_path)
+        (tmp_path / "small.txt").write_text("hi")
+        sub = tmp_path / "dir"
+        sub.mkdir()
+        (sub / "bigger.bin").write_bytes(b"x" * 2048)
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: add files")
+        monkeypatch.chdir(tmp_path)
+        files = dict(get_commit_files())
+        assert files == {"small.txt": 2, "dir/bigger.bin": 2048}
+
+    @pytest.mark.benchmark
+    def test_deletions_are_excluded(self, tmp_path, monkeypatch):
+        self._repo(tmp_path)
+        (tmp_path / "doomed.txt").write_text("x")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: add")
+        self._git(tmp_path, "rm", "-q", "doomed.txt")
+        self._git(tmp_path, "commit", "-qm", "chore: remove")
+        monkeypatch.chdir(tmp_path)
+        assert get_commit_files() == []
+
+    @pytest.mark.benchmark
+    def test_rev_names_the_commit(self, tmp_path, monkeypatch):
+        self._repo(tmp_path)
+        (tmp_path / "first.txt").write_text("1")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: first")
+        first = self._git(tmp_path, "rev-parse", "HEAD")
+        (tmp_path / "second.txt").write_text("22")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: second")
+        monkeypatch.chdir(tmp_path)
+        assert dict(get_commit_files(first)) == {"first.txt": 1}
+        assert dict(get_commit_files()) == {"second.txt": 2}
+
+    @pytest.mark.benchmark
+    def test_unresolvable_rev_is_empty(self, tmp_path, monkeypatch):
+        self._repo(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert get_commit_files("doesnotexist") == []

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -6,6 +6,7 @@ import subprocess
 import commit_check
 from commit_check import supports_color
 from commit_check.util import (
+    get_push_commits,
     get_tags_at,
     get_commit_files,
     parse_size,
@@ -1304,6 +1305,38 @@ class TestGetPushCommits:
         assert len(commits) == 2
         assert local in commits
         assert remote not in commits
+
+    # No benchmark mark: real-git test, see above.
+    def test_new_branch_excludes_what_the_remote_already_has(
+        self, tmp_path, monkeypatch
+    ):
+        """Pushing a new branch checks its own commits, not all of history.
+
+        A new ref arrives with an all-zero remote sha, so the range has to
+        come from what the remote cannot already reach -- otherwise the
+        first push of a branch would re-police every ancestor commit.
+        """
+        remote = tmp_path / "remote.git"
+        _run_git(tmp_path, "init", "-q", "--bare", str(remote))
+        work = tmp_path / "work"
+        work.mkdir()
+        _run_git(work, "init", "-q", "-b", "main")
+        _run_git(work, "config", "user.name", "T")
+        _run_git(work, "config", "user.email", "t@example.com")
+        _run_git(work, "remote", "add", "origin", str(remote))
+        (work / "base.txt").write_text("base")
+        _run_git(work, "add", "-A")
+        _run_git(work, "commit", "-qm", "chore: base")
+        _run_git(work, "push", "-q", "origin", "main")
+
+        _run_git(work, "checkout", "-qb", "feature")
+        (work / "new.txt").write_text("new")
+        _run_git(work, "add", "-A")
+        _run_git(work, "commit", "-qm", "feat: new")
+        tip = _run_git(work, "rev-parse", "HEAD")
+
+        monkeypatch.chdir(work)
+        assert get_push_commits(tip, "0" * 40) == [tip]
 
     @pytest.mark.benchmark
     def test_unresolvable_range_falls_back_to_the_tip(self, mocker):

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1286,10 +1286,21 @@ class TestPathspecBatches:
 
         batches = _pathspec_batches(["x" * 4000 for _ in range(20)])
         assert len(batches) > 1
+        # A batch may only pass the budget when it holds a single pathspec,
+        # which cannot be split any further.
         assert all(
-            sum(len(spec) + 1 for spec in b) <= _LS_TREE_ARG_BUDGET + 4020
+            sum(len(spec) + 1 for spec in b) <= _LS_TREE_ARG_BUDGET or len(b) == 1
             for b in batches
         )
+
+    @pytest.mark.benchmark
+    def test_one_oversized_path_is_its_own_batch(self):
+        from commit_check.util import _pathspec_batches, _LS_TREE_ARG_BUDGET
+
+        batches = _pathspec_batches(
+            ["a.txt", "x" * (_LS_TREE_ARG_BUDGET + 10), "b.txt"]
+        )
+        assert [len(b) for b in batches] == [1, 1, 1]
 
 
 class TestGetPushCommits:

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1120,7 +1120,9 @@ class TestGetCommitFiles:
         self._git(tmp_path, "config", "user.name", "T")
         self._git(tmp_path, "config", "user.email", "t@example.com")
 
-    @pytest.mark.benchmark
+    # No benchmark mark: CodSpeed executes marked tests more than once against
+    # the same tmp_path, and this test's mkdir/commit sequence only works on a
+    # fresh directory.
     def test_lists_touched_files_with_sizes(self, tmp_path, monkeypatch):
         self._repo(tmp_path)
         (tmp_path / "small.txt").write_text("hi")
@@ -1144,7 +1146,8 @@ class TestGetCommitFiles:
         monkeypatch.chdir(tmp_path)
         assert get_commit_files() == []
 
-    @pytest.mark.benchmark
+    # No benchmark mark: a second execution has nothing new to commit, so the
+    # helper's returncode assertion would fail under CodSpeed's re-runs.
     def test_rev_names_the_commit(self, tmp_path, monkeypatch):
         self._repo(tmp_path)
         (tmp_path / "first.txt").write_text("1")

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1163,3 +1163,11 @@ class TestGetCommitFiles:
         self._repo(tmp_path)
         monkeypatch.chdir(tmp_path)
         assert get_commit_files("doesnotexist") == []
+
+    @pytest.mark.benchmark
+    def test_ls_tree_failure_yields_no_files(self, mocker):
+        """A failing size lookup drops the batch instead of inventing data."""
+        diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
+        tree = mocker.Mock(returncode=128, stdout="", stderr="fatal: bad object")
+        mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, tree])
+        assert get_commit_files() == []

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1169,11 +1169,155 @@ class TestGetCommitFiles:
 
     @pytest.mark.benchmark
     def test_ls_tree_failure_yields_no_files(self, mocker):
-        """A failing size lookup drops the batch instead of inventing data."""
+        """A failing size lookup reports nothing rather than a partial set."""
         diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
         tree = mocker.Mock(returncode=128, stdout="", stderr="fatal: bad object")
         mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, tree])
         assert get_commit_files() == []
+
+    @pytest.mark.benchmark
+    def test_partial_batch_failure_reports_nothing(self, mocker):
+        """One failed batch must not shrink the set the rules then pass on."""
+        diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
+        ok = mocker.Mock(
+            returncode=0, stdout="100644 blob abc     5\ta.txt\0", stderr=""
+        )
+        bad = mocker.Mock(returncode=128, stdout="", stderr="fatal")
+        mocker.patch("commit_check.util.subprocess.run", side_effect=[diff, ok, bad])
+        mocker.patch(
+            "commit_check.util._pathspec_batches",
+            return_value=[[":(top,literal)a.txt"], [":(top,literal)b.txt"]],
+        )
+        assert get_commit_files() == []
+
+    @pytest.mark.benchmark
+    def test_unrunnable_command_line_reports_nothing(self, mocker):
+        """An OSError (Windows arg limits) is not an accidental pass."""
+        diff = mocker.Mock(returncode=0, stdout="a.txt\0", stderr="")
+        mocker.patch(
+            "commit_check.util.subprocess.run",
+            side_effect=[diff, OSError("arg list too long")],
+        )
+        assert get_commit_files() == []
+
+    # No benchmark mark: real-git tests are not safe under CodSpeed re-runs.
+    def test_runs_from_a_subdirectory(self, tmp_path, monkeypatch):
+        """Paths are repo-relative wherever commit-check is invoked from.
+
+        ls-tree reads pathspecs relative to the cwd, so without an anchored
+        pathspec every rule would find no files -- and pass -- in a commit
+        that fails at the repository root.
+        """
+        self._repo(tmp_path)
+        sub = tmp_path / "sub" / "deep"
+        sub.mkdir(parents=True)
+        (sub / "nested.txt").write_bytes(b"x" * 7)
+        (tmp_path / "top.txt").write_bytes(b"y" * 5)
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: add files")
+
+        monkeypatch.chdir(tmp_path)
+        from_root = dict(get_commit_files())
+        monkeypatch.chdir(sub)
+        from_sub = dict(get_commit_files())
+
+        assert from_root == {"sub/deep/nested.txt": 7, "top.txt": 5}
+        assert from_sub == from_root
+
+    # No benchmark mark: real-git test, see above.
+    def test_merge_commit_reports_what_it_brings_in(self, tmp_path, monkeypatch):
+        """A merge is diffed against its first parent, not treated as empty.
+
+        diff-tree prints nothing for a merge by default, which would let a
+        prohibited file arrive through a merge unexamined -- exactly the
+        commit CI checks on a pull request.
+        """
+        self._repo(tmp_path)
+        (tmp_path / "base.txt").write_text("base")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "chore: base")
+        self._git(tmp_path, "checkout", "-qb", "feature")
+        (tmp_path / "leaked.pem").write_text("KEY")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: add key")
+        self._git(tmp_path, "checkout", "-q", "-")
+        self._git(tmp_path, "merge", "-q", "--no-ff", "feature", "-m", "chore: merge")
+
+        monkeypatch.chdir(tmp_path)
+        assert dict(get_commit_files()) == {"leaked.pem": 3}
+
+
+class TestPathspecBatches:
+    @pytest.mark.benchmark
+    def test_paths_are_anchored_and_literal(self):
+        from commit_check.util import _pathspec_batches
+
+        assert _pathspec_batches(["a[1].txt"]) == [[":(top,literal)a[1].txt"]]
+
+    @pytest.mark.benchmark
+    def test_batches_are_capped_by_count(self):
+        from commit_check.util import _pathspec_batches
+
+        batches = _pathspec_batches([f"f{i}.txt" for i in range(1200)])
+        assert [len(b) for b in batches] == [500, 500, 200]
+
+    @pytest.mark.benchmark
+    def test_long_paths_split_before_the_count_cap(self):
+        """A few huge paths must not build a command line git cannot run."""
+        from commit_check.util import _pathspec_batches, _LS_TREE_ARG_BUDGET
+
+        batches = _pathspec_batches(["x" * 4000 for _ in range(20)])
+        assert len(batches) > 1
+        assert all(
+            sum(len(spec) + 1 for spec in b) <= _LS_TREE_ARG_BUDGET + 4020
+            for b in batches
+        )
+
+
+class TestGetPushCommits:
+    @staticmethod
+    def _git(tmp_path, *args):
+        result = subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, encoding="utf-8"
+        )
+        assert result.returncode == 0, result.stderr
+        return result.stdout.strip()
+
+    # No benchmark mark: real-git test, see above.
+    def test_range_covers_every_pushed_commit(self, tmp_path, monkeypatch):
+        from commit_check.util import get_push_commits
+
+        self._git(tmp_path, "init", "-q", "-b", "main")
+        self._git(tmp_path, "config", "user.name", "T")
+        self._git(tmp_path, "config", "user.email", "t@example.com")
+        (tmp_path / "base.txt").write_text("base")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "chore: base")
+        remote = self._git(tmp_path, "rev-parse", "HEAD")
+        (tmp_path / "a.txt").write_text("a")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: a")
+        (tmp_path / "b.txt").write_text("b")
+        self._git(tmp_path, "add", "-A")
+        self._git(tmp_path, "commit", "-qm", "feat: b")
+        local = self._git(tmp_path, "rev-parse", "HEAD")
+
+        monkeypatch.chdir(tmp_path)
+        commits = get_push_commits(local, remote)
+        assert len(commits) == 2
+        assert local in commits
+        assert remote not in commits
+
+    @pytest.mark.benchmark
+    def test_unresolvable_range_falls_back_to_the_tip(self, mocker):
+        """A range this clone cannot compute still leaves the tip worth checking."""
+        from commit_check.util import get_push_commits
+
+        mocker.patch(
+            "commit_check.util.subprocess.run",
+            return_value=mocker.Mock(returncode=128, stdout="", stderr="fatal"),
+        )
+        assert get_push_commits("deadbeef", "cafebabe") == ["deadbeef"]
 
 
 class TestParseSizeOverflow:


### PR DESCRIPTION
## Summary

Implements #558: file metadata checks in the `CC3xx` range. GitHub's push rules police file size, path patterns, and path length — but only on Team/Enterprise plans for private repositories ([GA announcement](``https://github.blog/changelog/2024-09-10-push-rules-are-now-generally-available-and-updates-to-custom-properties/));`` this brings the same policies to every plan and forge. The need is first-party: this organization once shipped a GitHub App private key committed as a `*.pem`, and a prohibited-pattern rule would have stopped it at commit time.

### The rules — all off by default

| Rule | Check | Config (`[files]`) |
|---|---|---|
| **CC302** | `file_size` | `max_size = "5MB"` (bytes, or KB/MB/GB suffix; binary units) |
| **CC303** | `file_pattern` | `prohibited_patterns = ["*.pem", ".env", "id_rsa*"]` (fnmatch; a bare pattern also matches the file name at any depth) |
| **CC304** | `path_length` | `max_path_length = 250` |

### Behavior

- **`--files` / `-f`** validates the files the commit at `HEAD` (or `--rev`) touches, reading only the paths and blob sizes recorded in the commit — **never file contents**, keeping the "not a code linter" promise. Content scanning (entropy, token detection) stays deliberately out of scope for gitleaks-class tools.
- Each rule exists only when its setting carries a usable value; malformed values (a non-table `[files]`, an unparsable size, a non-list pattern set) disable the rule rather than failing every commit. `--files` with an empty `[files]` section says so on stderr instead of passing silently.
- Deletion-only commits (and unresolvable revisions) **skip** — removing a file adds nothing to police. Submodule entries are ignored (no blob size).
- Failures name the first offender with a count of the rest: `big.bin (5 MB) (+2 more)`, `secrets/server.pem (pattern *.pem)`, `deep/path/… (62 characters)`.
- Full source plumbing like every other rule: `[files]` TOML section (`inherit_from` works), `CCHK_FILES_*` env vars, `--files-max-size` / `--files-prohibited-patterns` / `--files-max-path-length` CLI flags, JSON output with rule IDs and docs URLs.
- New **`check-files` pre-push hook** covers the tip commit locally; the Action/App cover every commit in CI. Paths are passed to `git ls-tree` as `:(literal)` pathspecs and batched, so glob characters in file names and very large commits are both safe.

## Testing

- 31 new tests: size parsing accept/reject matrix, real-git `get_commit_files` integration (touched files with sizes, deletions excluded, `--rev` targeting, unresolvable rev), validator pass/fail/skip/offender-counting for all three rules, builder on/off/independence/malformed-config, env + CLI plumbing, help output
- Full suite: 661 passed (the one failure, `test_load_config_file_permission_error`, is the known sandbox artifact — root ignores `chmod 000`; identical on clean `main`)
- `pre-commit run` clean (ruff check/format, mypy, codespell, yaml)
- End-to-end in scratch repos: CC303 catches `secrets/server.pem`, CC302 catches a 5 KB file over a 1 KB limit via `--rev`, CC304 catches a 62-char path over a 40 limit, deletion-only commit skips with exit 0, JSON carries rule IDs

## Release note

Like #559, the rules reference on commit-check.com needs CC302–CC304 sections when this ships; `docs_url` already points at the anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional checks for committed-file size, prohibited path patterns, and path length.
  * Added `--files`, related configuration options, and environment variable support.
  * Added clear validation messages and rule identifiers for file-policy violations.
  * Added a pre-push hook to run file checks automatically when configured.

* **Documentation**
  * Added usage instructions, configuration details, limitations, and feature comparison information to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->