### PR TITLE
docs: mention the Commit Check GitHub App as an enforcement point

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@
 
 It validates commit messages, branch names, author identity, signoff trailers,
 AI attribution policy, and push safety — using one versioned TOML policy across
-local hooks, CI, GitHub Actions, and AI automation.
+local hooks, CI, GitHub Actions, the hosted GitHub App, and AI automation.
 
 - **One policy file:** `cchk.toml`
-- **Multiple enforcement points:** CLI, pre-commit, CI / GitHub Actions
+- **Multiple enforcement points:** CLI, pre-commit, CI / GitHub Actions, or the [Commit Check GitHub App](https://github.com/marketplace/commit-check) with no workflow file
 - **Machine-readable output:** JSON + Python API for automation and AI agents
 
 ![commit-check demo](https://github.com/commit-check/commit-check/raw/main/assets/demo.gif)


### PR DESCRIPTION
The README lists where the policy is enforced — CLI, pre-commit, CI / GitHub Actions — and the hosted App is now on the Marketplace: https://github.com/marketplace/commit-check. Two lines: the intro sentence and the *Multiple enforcement points* bullet, which links to the listing and says the one thing that distinguishes the App, no workflow file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Overview to include the hosted Commit Check GitHub App as an enforcement point.
  * Added a marketplace link and clarified that the GitHub App does not require a workflow file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->