### PR TITLE
feat: name the correction when a failed check has an unambiguous fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ echo "feat: add streaming support" | commit-check -m --format json
       "value": "feat: add streaming support",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc001"
     },
     {
@@ -343,6 +344,7 @@ echo "feat: add streaming support" | commit-check -m --format json
       "value": "feat: add streaming support",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc004"
     },
     {
@@ -352,6 +354,7 @@ echo "feat: add streaming support" | commit-check -m --format json
       "value": "feat: add streaming support",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc005"
     }
   ]
@@ -376,6 +379,7 @@ echo "wip bad commit" | commit-check -m --format json
       "value": "wip bad commit",
       "error": "The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
       "suggest": "Use <type>(<scope>): <description>, where <type> is one of: feat, fix, docs, style, refactor, test, chore, perf, build, ci",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc001"
     },
     {
@@ -385,6 +389,7 @@ echo "wip bad commit" | commit-check -m --format json
       "value": "wip bad commit",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc004"
     },
     {
@@ -394,9 +399,36 @@ echo "wip bad commit" | commit-check -m --format json
       "value": "wip bad commit",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc005"
     }
   ]
+}
+```
+
+When the correction is mechanical, `fix` carries the corrected value and
+`suggest` names it, so an agent (or a person) can apply it without
+interpreting anything: a type written `Fix` or misspelt `feta`, a missing
+colon, a lowercase description under `subject_capitalized`, a `WIP:` marker,
+a missing `Signed-off-by` trailer, a branch typed `Feature/x`, or AI
+attribution lines under `ai_attribution = "forbid"`. Anything that takes a
+judgment, such as choosing a type for a bare subject or shortening a long one,
+leaves `fix` empty and `suggest` generic.
+
+```bash
+echo "Fix: add streaming support" | commit-check -m --format json
+```
+
+```json
+{
+  "rule_id": "CC001",
+  "check": "message",
+  "status": "fail",
+  "value": "Fix: add streaming support",
+  "error": "The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
+  "suggest": "Use \"fix: add streaming support\"",
+  "fix": "fix: add streaming support",
+  "docs_url": "https://commit-check.com/rules/#cc001"
 }
 ```
 
@@ -481,6 +513,7 @@ print(result["status"])          # "fail" — 'docs' not in allowed types
             "value":    "<actual value that was checked>",
             "error":    "<human-readable error description>",
             "suggest":  "<how to fix>",
+            "fix":      "<the corrected value, when it is unambiguous; else empty>",
             "docs_url": "<link to the rule's documentation>",
         },
         # ... one entry per active rule
@@ -514,6 +547,7 @@ echo "chore(deps): bump commit-check" | CCHK_IGNORE_AUTHORS="dependabot[bot]" co
       "value": "",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc001"
     },
     {
@@ -523,6 +557,7 @@ echo "chore(deps): bump commit-check" | CCHK_IGNORE_AUTHORS="dependabot[bot]" co
       "value": "",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc004"
     },
     {
@@ -532,6 +567,7 @@ echo "chore(deps): bump commit-check" | CCHK_IGNORE_AUTHORS="dependabot[bot]" co
       "value": "",
       "error": "",
       "suggest": "",
+      "fix": "",
       "docs_url": "https://commit-check.com/rules/#cc005"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -421,16 +421,23 @@ echo "Fix: add streaming support" | commit-check -m --format json
 
 ```json
 {
-  "rule_id": "CC001",
-  "check": "message",
   "status": "fail",
-  "value": "Fix: add streaming support",
-  "error": "The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
-  "suggest": "Use \"fix: add streaming support\"",
-  "fix": "fix: add streaming support",
-  "docs_url": "https://commit-check.com/rules/#cc001"
+  "checks": [
+    {
+      "rule_id": "CC001",
+      "check": "message",
+      "status": "fail",
+      "value": "Fix: add streaming support",
+      "error": "The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
+      "suggest": "Use \"fix: add streaming support\"",
+      "fix": "fix: add streaming support",
+      "docs_url": "https://commit-check.com/rules/#cc001"
+    }
+  ]
 }
 ```
+
+(The passing checks are omitted from this example.)
 
 ### Quieter Human-Readable Output
 

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -27,6 +27,7 @@ Return-value schema (all functions)::
                 "value":   "<actual value that was checked>",
                 "error":   "<error description>",
                 "suggest": "<how to fix>",
+                "fix":     "<the corrected value when the fix is unambiguous; else empty>",
             },
             ...
         ]

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -1,6 +1,7 @@
 """Clean validation engine following SOLID principles."""
 
 from __future__ import annotations
+import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -453,21 +454,30 @@ class SubjectCapitalizationValidator(SubjectValidator):
         if subject.startswith("Merge "):
             return ValidationResult.SKIP
 
-        # For conventional commits, check the description part after the colon
+        if self._is_capitalized(subject):
+            return ValidationResult.PASS
+
+        # The corrected subject has to pass this same check, or it is no fix.
+        fix = fix_subject_case(subject, capitalize=True)
+        if fix and not self._is_capitalized(fix):
+            fix = None
+        self._print_failure(subject, fix=fix)
+        return ValidationResult.FAIL
+
+    @staticmethod
+    def _is_capitalized(subject: str) -> bool:
+        """Whether the description starts upper-case, after any Conventional Commits prefix.
+
+        Only a prefix that ends in a colon is a type. Without one, the first
+        word is the description itself, so "Add feature" is judged on its
+        "A" and not on the "f" that follows, and "Update" alone is judged at
+        all.
+        """
         import re
 
-        match = re.match(r"^(?:\w+(?:\([^)]*\))?[!:]?\s*)(.*)", subject)
-        if match:
-            description = match.group(1).strip()
-            if description and description[0].isupper():
-                return ValidationResult.PASS
-        else:
-            # For non-conventional commits, check the first character
-            if subject and subject[0].isupper():
-                return ValidationResult.PASS
-
-        self._print_failure(subject, fix=fix_subject_case(subject, capitalize=True))
-        return ValidationResult.FAIL
+        match = re.match(r"^\w+(?:\([^)]*\))?!?:\s*(.*)", subject)
+        description = match.group(1).strip() if match else subject
+        return bool(description) and description[0].isupper()
 
 
 class SubjectImperativeValidator(SubjectValidator):
@@ -658,7 +668,9 @@ class BranchValidator(BaseValidator):
         fix = suggest = None
         if fixed and re.match(self.rule.regex, fixed):
             fix = fixed
-            suggest = f'Rename the branch to "{fixed}" (git branch -m {fixed})'
+            suggest = (
+                f'Rename the branch to "{fixed}" (git branch -m {shlex.quote(fixed)})'
+            )
         self._print_failure(branch_name, fix=fix, suggest=suggest)
         return ValidationResult.FAIL
 

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -15,7 +15,9 @@ from commit_check.ai_signatures import (
 from commit_check.util import (
     fetch_remote_ref,
     fetch_upstream_ref,
+    get_commit_author_identity,
     get_commit_info,
+    get_git_user_identity,
     get_git_config_value,
     get_branch_name,
     get_commit_files,
@@ -1022,20 +1024,24 @@ class SignoffValidator(BaseValidator):
 
     @staticmethod
     def _resolve_author_identity(context: ValidationContext) -> tuple[str, str]:
-        """The (name, email) the sign-off would carry, by the same modes as the author."""
+        """The (name, email) the sign-off would carry, by the same modes as the author.
+
+        This runs only on a failure, but a hook still waits on it, so each
+        mode asks git once and falls back to a second call only when the
+        first left a part blank.
+        """
         if context.rev is not None:
-            return get_commit_info("an", context.rev), get_commit_info(
-                "ae", context.rev
-            )
-        if context.stdin_text is not None or context.commit_file is not None:
-            return (
-                get_git_config_value("user.name") or get_commit_info("an"),
-                get_git_config_value("user.email") or get_commit_info("ae"),
-            )
-        return (
-            get_commit_info("an") or get_git_config_value("user.name"),
-            get_commit_info("ae") or get_git_config_value("user.email"),
+            return get_commit_author_identity(context.rev)
+        pending = context.stdin_text is not None or context.commit_file is not None
+        name, email = (
+            get_git_user_identity() if pending else get_commit_author_identity()
         )
+        if not name or not email:
+            fallback_name, fallback_email = (
+                get_commit_author_identity() if pending else get_git_user_identity()
+            )
+            name, email = name or fallback_name, email or fallback_email
+        return name, email
 
 
 class BodyValidator(BaseValidator):

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -29,6 +29,14 @@ from commit_check.util import (
     git_rev_parse_verify,
 )
 from commit_check.imperatives import IMPERATIVES, NON_IMPERATIVE_LOOKALIKES
+from commit_check.fixes import (
+    fix_branch_type,
+    fix_conventional_header,
+    fix_subject_case,
+    fix_wip,
+    signoff_trailer,
+    strip_lines_containing,
+)
 
 
 class ValidationResult(IntEnum):
@@ -96,6 +104,10 @@ class CheckOutcome:
     value: str = ""
     error: str = ""
     suggest: str = ""
+    # The corrected value when the fix is unambiguous (a type's case, a WIP
+    # marker, a missing trailer); empty when fixing it takes a judgment the
+    # tool should not make. Consumers can offer it as a one-step correction.
+    fix: str = ""
     rule_id: str = ""
     docs_url: str = ""
 
@@ -108,6 +120,7 @@ class CheckOutcome:
             "value": self.value,
             "error": self.error,
             "suggest": self.suggest,
+            "fix": self.fix,
             "docs_url": self.docs_url,
         }
 
@@ -320,16 +333,32 @@ class BaseValidator(ABC):
                 return True
         return context.stdin_text is None and not has_commits()
 
-    def _print_failure(self, actual_value: str, regex_or_constraint: str = "") -> None:
-        """Record and (unless suppressed) print a standardised failure message."""
+    def _print_failure(
+        self,
+        actual_value: str,
+        regex_or_constraint: str = "",
+        *,
+        fix: str | None = None,
+        suggest: str | None = None,
+    ) -> None:
+        """Record and (unless suppressed) print a standardised failure message.
+
+        ``fix`` is the corrected value when the validator can name it without
+        guessing; it replaces the rule's generic suggestion with a concrete
+        one (``suggest`` overrides the wording) and travels to structured
+        consumers as its own field.
+        """
         rule_dict = self.rule.to_dict()
+        if fix or suggest:
+            rule_dict["suggest"] = suggest or f'Use "{fix}"'
 
         # Always store structured failure details for programmatic consumers.
         self._last_failure = {
             "check": self.rule.check,
             "value": actual_value,
             "error": self.rule.error or "",
-            "suggest": self.rule.suggest or "",
+            "suggest": rule_dict.get("suggest") or self.rule.suggest or "",
+            "fix": fix or "",
         }
 
         if not self._suppress_output:
@@ -361,7 +390,20 @@ class CommitMessageValidator(BaseValidator):
         if self.rule.regex and re.match(self.rule.regex, message):
             return ValidationResult.PASS
 
-        self._print_failure(message)
+        # Name the correction only when it is mechanical: a type's case or a
+        # one-letter slip, a colon that went missing. The corrected header
+        # has to satisfy the rule itself, or it is no fix at all.
+        subject, newline, rest = message.partition("\n")
+        fixed_subject = fix_conventional_header(subject, self.rule.allowed)
+        fix = suggest = None
+        if (
+            fixed_subject
+            and self.rule.regex
+            and re.match(self.rule.regex, fixed_subject)
+        ):
+            fix = fixed_subject + newline + rest
+            suggest = f'Use "{fixed_subject}"'
+        self._print_failure(message, fix=fix, suggest=suggest)
         return ValidationResult.FAIL
 
 
@@ -424,7 +466,7 @@ class SubjectCapitalizationValidator(SubjectValidator):
             if subject and subject[0].isupper():
                 return ValidationResult.PASS
 
-        self._print_failure(subject)
+        self._print_failure(subject, fix=fix_subject_case(subject, capitalize=True))
         return ValidationResult.FAIL
 
 
@@ -612,7 +654,12 @@ class BranchValidator(BaseValidator):
         if re.match(self.rule.regex, branch_name):
             return ValidationResult.PASS
 
-        self._print_failure(branch_name)
+        fixed = fix_branch_type(branch_name, self.rule.allowed)
+        fix = suggest = None
+        if fixed and re.match(self.rule.regex, fixed):
+            fix = fixed
+            suggest = f'Rename the branch to "{fixed}" (git branch -m {fixed})'
+        self._print_failure(branch_name, fix=fix, suggest=suggest)
         return ValidationResult.FAIL
 
 
@@ -953,8 +1000,30 @@ class SignoffValidator(BaseValidator):
         if self.rule.regex and re.search(self.rule.regex, message):
             return ValidationResult.PASS
 
-        self._print_failure(message)
+        trailer = signoff_trailer(*self._resolve_author_identity(context))
+        fix = suggest = None
+        if trailer:
+            fix = f"{message.rstrip()}\n\n{trailer}"
+            suggest = f'Add the trailer "{trailer}" (git commit --signoff, or --amend --signoff for an existing commit)'
+        self._print_failure(message, fix=fix, suggest=suggest)
         return ValidationResult.FAIL
+
+    @staticmethod
+    def _resolve_author_identity(context: ValidationContext) -> tuple[str, str]:
+        """The (name, email) the sign-off would carry, by the same modes as the author."""
+        if context.rev is not None:
+            return get_commit_info("an", context.rev), get_commit_info(
+                "ae", context.rev
+            )
+        if context.stdin_text is not None or context.commit_file is not None:
+            return (
+                get_git_config_value("user.name") or get_commit_info("an"),
+                get_git_config_value("user.email") or get_commit_info("ae"),
+            )
+        return (
+            get_commit_info("an") or get_git_config_value("user.name"),
+            get_commit_info("ae") or get_git_config_value("user.email"),
+        )
 
 
 class BodyValidator(BaseValidator):
@@ -1145,7 +1214,12 @@ class CommitTypeValidator(BaseValidator):
         is_allowed = self._is_commit_type_allowed(message)
 
         if not is_allowed:
-            self._print_failure(message)
+            fix = suggest = None
+            if self.rule.check == "allow_wip_commits":
+                fix = fix_wip(message)
+                if fix:
+                    suggest = f'Drop the WIP marker: "{fix.splitlines()[0]}"'
+            self._print_failure(message, fix=fix, suggest=suggest)
             return ValidationResult.FAIL
 
         return ValidationResult.PASS
@@ -1228,20 +1302,31 @@ class AiAttributionValidator(BaseValidator):
             return ValidationResult.PASS
 
         tools = {s["tool"] for s in signatures}
+        fix = strip_lines_containing(
+            message, [s.get("matched_text", "") for s in signatures]
+        )
         self._record_failure(
             value=", ".join(sorted(tools)),
             error=f"AI-assisted commit is forbidden — detected tools: {', '.join(sorted(tools))}",
-            suggest="This project forbids AI-assisted commits. Remove AI trailers and re-commit.",
+            suggest=(
+                "This project forbids AI-assisted commits. Remove the AI trailer lines and re-commit."
+                if fix
+                else "This project forbids AI-assisted commits. Remove AI trailers and re-commit."
+            ),
+            fix=fix,
         )
         return ValidationResult.FAIL
 
-    def _record_failure(self, value: str, error: str, suggest: str) -> None:
+    def _record_failure(
+        self, value: str, error: str, suggest: str, fix: str | None = None
+    ) -> None:
         """Record a failure with dynamic error/suggest messages."""
         self._last_failure = {
             "check": self.rule.check,
             "value": value,
             "error": error,
             "suggest": suggest,
+            "fix": fix or "",
         }
         if not self._suppress_output:
             # Pass dynamic messages to the printer by creating a dict with
@@ -1364,6 +1449,7 @@ class ValidationEngine:
                         value=failure.get("value", ""),
                         error=failure.get("error", ""),
                         suggest=failure.get("suggest", ""),
+                        fix=failure.get("fix", ""),
                         rule_id=rule.rule_id or "",
                         docs_url=rule.docs_url or "",
                     )

--- a/commit_check/fixes.py
+++ b/commit_check/fixes.py
@@ -46,10 +46,13 @@ def _closest(word: str, allowed: list[str]) -> str | None:
         return lowered
     if len(lowered) < 3:
         return None
-    for candidate in allowed:
+    # A near-miss is within a letter of its target; anything else is a
+    # different word, and there is no point measuring how different.
+    near = [c for c in allowed if abs(len(c) - len(lowered)) <= 1]
+    for candidate in near:
         if _transposed(lowered, candidate):
             return candidate
-    close = difflib.get_close_matches(lowered, allowed, n=1, cutoff=0.8)
+    close = difflib.get_close_matches(lowered, near, n=1, cutoff=0.8)
     return close[0] if close else None
 
 

--- a/commit_check/fixes.py
+++ b/commit_check/fixes.py
@@ -26,7 +26,12 @@ def _transposed(a: str, b: str) -> bool:
     if len(a) != len(b) or a == b:
         return False
     diff = [i for i, (x, y) in enumerate(zip(a, b)) if x != y]
-    return len(diff) == 2 and diff[1] == diff[0] + 1 and a[diff[0]] == b[diff[1]] and a[diff[1]] == b[diff[0]]
+    return (
+        len(diff) == 2
+        and diff[1] == diff[0] + 1
+        and a[diff[0]] == b[diff[1]]
+        and a[diff[1]] == b[diff[0]]
+    )
 
 
 def _closest(word: str, allowed: list[str]) -> str | None:
@@ -48,7 +53,9 @@ def _closest(word: str, allowed: list[str]) -> str | None:
     return close[0] if close else None
 
 
-def fix_conventional_header(subject: str, allowed_types: list[str] | None) -> str | None:
+def fix_conventional_header(
+    subject: str, allowed_types: list[str] | None
+) -> str | None:
     """A corrected Conventional Commits header, or None when it takes a guess.
 
     Fixes the type's case and small misspellings, a missing colon after a

--- a/commit_check/fixes.py
+++ b/commit_check/fixes.py
@@ -1,0 +1,128 @@
+"""Deterministic corrections for failed checks.
+
+A suggestion is only worth more than the rule's generic text when the fix is
+unambiguous: a type written ``Fix`` where ``fix`` is allowed, a type misspelt
+by a letter, a missing space after the colon, a ``WIP:`` marker to drop, a
+sign-off trailer to add. Anything that needs a judgment — which type a bare
+subject deserves, how to shorten a long one, how to phrase it imperatively —
+is left to the human, and these functions return ``None`` so the caller keeps
+the generic suggestion. Every function here is pure and free of git.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+
+# type, optional scope, optional bang, optional colon, the rest. Lenient on
+# purpose: this is the shape of a subject that *tried* to be conventional.
+_HEADER = re.compile(r"^\s*([A-Za-z]+)(\([^)]*\))?(!)?(\s*:\s*|\s+)(\S.*?)\s*$")
+_CONVENTIONAL_PREFIX = re.compile(r"^(\w+(?:\([^)]*\))?!?:\s*)(.*)$")
+_WIP = re.compile(r"^\s*(?:\[wip\]|wip:|wip\b)\s*[-:]?\s*", re.IGNORECASE)
+
+
+def _transposed(a: str, b: str) -> bool:
+    """Whether *a* is *b* with one pair of adjacent letters swapped (``feta``/``feat``)."""
+    if len(a) != len(b) or a == b:
+        return False
+    diff = [i for i, (x, y) in enumerate(zip(a, b)) if x != y]
+    return len(diff) == 2 and diff[1] == diff[0] + 1 and a[diff[0]] == b[diff[1]] and a[diff[1]] == b[diff[0]]
+
+
+def _closest(word: str, allowed: list[str]) -> str | None:
+    """The allowed word *word* is a near-miss of, or None.
+
+    Case is forgiven outright; a swapped pair of letters or a one-letter slip
+    is matched, tightly enough that ``feat`` never turns into ``test`` and
+    ``text`` never turns into ``test`` either.
+    """
+    lowered = word.lower()
+    if lowered in allowed:
+        return lowered
+    if len(lowered) < 3:
+        return None
+    for candidate in allowed:
+        if _transposed(lowered, candidate):
+            return candidate
+    close = difflib.get_close_matches(lowered, allowed, n=1, cutoff=0.8)
+    return close[0] if close else None
+
+
+def fix_conventional_header(subject: str, allowed_types: list[str] | None) -> str | None:
+    """A corrected Conventional Commits header, or None when it takes a guess.
+
+    Fixes the type's case and small misspellings, a missing colon after a
+    recognised type, and the spacing around the colon. Does not invent a
+    type: a subject with no recognisable type is the author's to fix.
+    """
+    if not allowed_types:
+        return None
+    match = _HEADER.match(subject)
+    if not match:
+        return None
+    raw_type, scope, bang, _sep, description = match.groups()
+    fixed_type = _closest(raw_type, allowed_types)
+    if fixed_type is None or not description:
+        return None
+    fixed = f"{fixed_type}{scope or ''}{bang or ''}: {description}"
+    return fixed if fixed != subject else None
+
+
+def fix_subject_case(subject: str, capitalize: bool = True) -> str | None:
+    """The subject with its description's first letter in the required case."""
+    match = _CONVENTIONAL_PREFIX.match(subject)
+    prefix, description = (match.group(1), match.group(2)) if match else ("", subject)
+    if not description or not description[0].isalpha():
+        return None
+    first = description[0].upper() if capitalize else description[0].lower()
+    fixed = f"{prefix}{first}{description[1:]}"
+    return fixed if fixed != subject else None
+
+
+def fix_wip(message: str) -> str | None:
+    """The message without its work-in-progress marker, or None if that is all there was."""
+    stripped = _WIP.sub("", message, count=1)
+    if stripped == message or not stripped.strip():
+        return None
+    return stripped
+
+
+def signoff_trailer(name: str, email: str) -> str | None:
+    """The ``Signed-off-by`` line for this author, or None without both parts."""
+    if not name or not email:
+        return None
+    return f"Signed-off-by: {name} <{email}>"
+
+
+def fix_branch_type(branch: str, allowed_types: list[str] | None) -> str | None:
+    """The branch with its type prefix corrected, or None when there is no near-miss."""
+    if not allowed_types or "/" not in branch:
+        return None
+    raw_type, rest = branch.split("/", 1)
+    if not rest:
+        return None
+    fixed_type = _closest(raw_type, allowed_types)
+    if fixed_type is None:
+        return None
+    fixed = f"{fixed_type}/{rest}"
+    return fixed if fixed != branch else None
+
+
+def strip_lines_containing(message: str, fragments: list[str]) -> str | None:
+    """The message without any line that contains one of *fragments*.
+
+    Used to drop AI-attribution trailers: the signature scanner reports the
+    text it matched, and the line carrying it is what has to go. Returns
+    None when nothing would change or nothing would be left.
+    """
+    if not fragments:
+        return None
+    kept = [
+        line
+        for line in message.splitlines()
+        if not any(fragment and fragment in line for fragment in fragments)
+    ]
+    if len(kept) == len(message.splitlines()):
+        return None
+    result = "\n".join(kept).strip()
+    return result or None

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -501,6 +501,29 @@ def get_git_config_value(key: str) -> str:
         return ""
 
 
+def get_git_user_identity() -> tuple[str, str]:
+    """The configured ``user.name`` and ``user.email``, in one git call.
+
+    Either part is an empty string when it is not set.
+    """
+    try:
+        output = cmd_output(["git", "config", "--get-regexp", r"^user\.(name|email)$"])
+    except CalledProcessError:
+        return "", ""
+    identity = {"user.name": "", "user.email": ""}
+    for line in output.splitlines():
+        key, _, value = line.partition(" ")
+        if key in identity:
+            identity[key] = value.strip()
+    return identity["user.name"], identity["user.email"]
+
+
+def get_commit_author_identity(sha: str = "HEAD") -> tuple[str, str]:
+    """The author name and email of a commit, in one git call."""
+    name, _, email = get_commit_info("an%x1f%ae", sha).partition("\x1f")
+    return name.strip(), email.strip()
+
+
 def git_merge_base(target_branch: str, current_branch: str) -> int:
     """Check ancestors for a given commit.
     :param target_branch: target branch

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -506,10 +506,8 @@ def get_git_user_identity() -> tuple[str, str]:
 
     Either part is an empty string when it is not set.
     """
-    try:
-        output = cmd_output(["git", "config", "--get-regexp", r"^user\.(name|email)$"])
-    except CalledProcessError:
-        return "", ""
+    # cmd_output never raises; an unset key yields an empty output.
+    output = cmd_output(["git", "config", "--get-regexp", r"^user\.(name|email)$"])
     identity = {"user.name": "", "user.email": ""}
     for line in output.splitlines():
         key, _, value = line.partition(" ")

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -5,7 +5,9 @@ from unittest.mock import patch
 from commit_check.engine import ValidationContext, ValidationEngine
 from commit_check.rule_builder import RuleBuilder, ValidationRule
 
-CONVENTIONAL = r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?: \S.*"
+CONVENTIONAL = (
+    r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?: \S.*"
+)
 TYPES = [
     "build",
     "chore",
@@ -22,7 +24,9 @@ TYPES = [
 
 
 def failed(rules, **context):
-    outcomes = ValidationEngine(rules).validate_all_detailed(ValidationContext(**context))
+    outcomes = ValidationEngine(rules).validate_all_detailed(
+        ValidationContext(**context)
+    )
     fails = [o for o in outcomes if o.status == "fail"]
     assert len(fails) == 1, outcomes
     return fails[0]
@@ -118,7 +122,10 @@ class TestSignoffFix:
     @patch("commit_check.engine.get_commit_info", return_value="")
     @patch("commit_check.engine.get_git_config_value")
     def test_trailer_uses_local_identity_for_pending_message(self, config, _info):
-        config.side_effect = {"user.name": "Jane Doe", "user.email": "jane@example.com"}.get
+        config.side_effect = {
+            "user.name": "Jane Doe",
+            "user.email": "jane@example.com",
+        }.get
         out = failed([self.rule()], stdin_text="feat: add x")
         assert out.fix == "feat: add x\n\nSigned-off-by: Jane Doe <jane@example.com>"
         assert out.suggest == (
@@ -159,7 +166,10 @@ class TestBranchFix:
     def test_type_case_is_corrected(self):
         out = failed([self.rule()], stdin_text="Feature/login")
         assert out.fix == "feature/login"
-        assert out.suggest == 'Rename the branch to "feature/login" (git branch -m feature/login)'
+        assert (
+            out.suggest
+            == 'Rename the branch to "feature/login" (git branch -m feature/login)'
+        )
 
     def test_unrelated_prefix_keeps_generic_suggestion(self):
         out = failed([self.rule()], stdin_text="stuff/login")
@@ -198,7 +208,9 @@ class TestBuiltRulesCarryAllowedTypes:
         assert out.rule_id == "CC001"
 
     def test_custom_types_drive_the_fix(self):
-        rules = RuleBuilder({"commit": {"allow_commit_types": ["feat", "fix"]}}).build_all_rules()
+        rules = RuleBuilder(
+            {"commit": {"allow_commit_types": ["feat", "fix"]}}
+        ).build_all_rules()
         message_rules = [r for r in rules if r.check == "message"]
         # "docs" is not allowed here, so it is not a near-miss of anything.
         out = failed(message_rules, stdin_text="Docs: add x")

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -1,0 +1,205 @@
+"""Validators name the correction when it is unambiguous, and only then."""
+
+from unittest.mock import patch
+
+from commit_check.engine import ValidationContext, ValidationEngine
+from commit_check.rule_builder import RuleBuilder, ValidationRule
+
+CONVENTIONAL = r"^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?!?: \S.*"
+TYPES = [
+    "build",
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "perf",
+    "refactor",
+    "revert",
+    "style",
+    "test",
+]
+
+
+def failed(rules, **context):
+    outcomes = ValidationEngine(rules).validate_all_detailed(ValidationContext(**context))
+    fails = [o for o in outcomes if o.status == "fail"]
+    assert len(fails) == 1, outcomes
+    return fails[0]
+
+
+class TestMessageFixes:
+    def rule(self):
+        return ValidationRule(
+            check="message",
+            regex=CONVENTIONAL,
+            error="Not conventional",
+            suggest="Use a conventional type",
+            allowed=TYPES,
+        )
+
+    def test_type_case_is_corrected(self):
+        out = failed([self.rule()], stdin_text="Fix: add x")
+        assert out.fix == "fix: add x"
+        assert out.suggest == 'Use "fix: add x"'
+
+    def test_misspelt_type_is_corrected(self):
+        out = failed([self.rule()], stdin_text="feta(api): add x")
+        assert out.fix == "feat(api): add x"
+
+    def test_missing_colon_is_corrected(self):
+        out = failed([self.rule()], stdin_text="docs update readme")
+        assert out.fix == "docs: update readme"
+
+    def test_body_is_kept_with_the_fix(self):
+        out = failed([self.rule()], stdin_text="Fix: add x\n\nSome body")
+        assert out.fix == "fix: add x\n\nSome body"
+        assert out.suggest == 'Use "fix: add x"'
+
+    def test_no_recognisable_type_keeps_generic_suggestion(self):
+        out = failed([self.rule()], stdin_text="add x")
+        assert out.fix == ""
+        assert out.suggest == "Use a conventional type"
+
+    def test_fix_field_is_serialised(self):
+        out = failed([self.rule()], stdin_text="Fix: add x")
+        assert out.to_dict()["fix"] == "fix: add x"
+
+    def test_no_fix_serialises_as_empty_string(self):
+        out = failed([self.rule()], stdin_text="add x")
+        assert out.to_dict()["fix"] == ""
+
+
+class TestSubjectCapitalizationFix:
+    def test_description_is_capitalised(self):
+        rule = ValidationRule(
+            check="subject_capitalized",
+            error="Lowercase subject",
+            suggest="Capitalise the subject",
+        )
+        out = failed([rule], stdin_text="feat: add x")
+        assert out.fix == "feat: Add x"
+        assert out.suggest == 'Use "feat: Add x"'
+
+
+class TestWipFix:
+    def test_marker_is_dropped(self):
+        rule = ValidationRule(
+            check="allow_wip_commits",
+            value=False,
+            error="WIP commits are not allowed",
+            suggest="Finish the work",
+        )
+        out = failed([rule], stdin_text="WIP: feat: add x\n\nbody")
+        assert out.fix == "feat: add x\n\nbody"
+        assert out.suggest == 'Drop the WIP marker: "feat: add x"'
+
+    def test_bare_marker_keeps_generic_suggestion(self):
+        rule = ValidationRule(
+            check="allow_wip_commits",
+            value=False,
+            error="WIP commits are not allowed",
+            suggest="Finish the work",
+        )
+        out = failed([rule], stdin_text="WIP")
+        assert out.fix == ""
+        assert out.suggest == "Finish the work"
+
+
+class TestSignoffFix:
+    def rule(self):
+        return ValidationRule(
+            check="require_signed_off_by",
+            regex=r"Signed-off-by: .+ <.+@.+>",
+            error="Missing sign-off",
+            suggest="Run git commit --signoff",
+        )
+
+    @patch("commit_check.engine.get_commit_info", return_value="")
+    @patch("commit_check.engine.get_git_config_value")
+    def test_trailer_uses_local_identity_for_pending_message(self, config, _info):
+        config.side_effect = {"user.name": "Jane Doe", "user.email": "jane@example.com"}.get
+        out = failed([self.rule()], stdin_text="feat: add x")
+        assert out.fix == "feat: add x\n\nSigned-off-by: Jane Doe <jane@example.com>"
+        assert out.suggest == (
+            'Add the trailer "Signed-off-by: Jane Doe <jane@example.com>" '
+            "(git commit --signoff, or --amend --signoff for an existing commit)"
+        )
+
+    @patch("commit_check.engine.get_git_config_value", return_value="")
+    @patch("commit_check.engine.get_commit_info")
+    def test_trailer_uses_commit_author_for_a_revision(self, info, _config):
+        info.side_effect = lambda fmt, rev=None: {
+            "s": "feat: add x",
+            "b": "",
+            "an": "Rev Author",
+            "ae": "rev@example.com",
+        }.get(fmt, "")
+        out = failed([self.rule()], rev="abc123")
+        assert out.fix.endswith("Signed-off-by: Rev Author <rev@example.com>")
+
+    @patch("commit_check.engine.get_commit_info", return_value="")
+    @patch("commit_check.engine.get_git_config_value", return_value="")
+    def test_unknown_identity_keeps_generic_suggestion(self, _config, _info):
+        out = failed([self.rule()], stdin_text="feat: add x")
+        assert out.fix == ""
+        assert out.suggest == "Run git commit --signoff"
+
+
+class TestBranchFix:
+    def rule(self):
+        return ValidationRule(
+            check="branch",
+            regex=r"^(feature|bugfix|hotfix)/.+|^main$",
+            error="Bad branch name",
+            suggest="Use type/description",
+            allowed=["feature", "bugfix", "hotfix"],
+        )
+
+    def test_type_case_is_corrected(self):
+        out = failed([self.rule()], stdin_text="Feature/login")
+        assert out.fix == "feature/login"
+        assert out.suggest == 'Rename the branch to "feature/login" (git branch -m feature/login)'
+
+    def test_unrelated_prefix_keeps_generic_suggestion(self):
+        out = failed([self.rule()], stdin_text="stuff/login")
+        assert out.fix == ""
+        assert out.suggest == "Use type/description"
+
+
+class TestAiAttributionFix:
+    def rule(self):
+        return ValidationRule(
+            check="ai_attribution",
+            value="forbid",
+            error="AI attribution forbidden",
+            suggest="Remove AI trailers",
+        )
+
+    def test_trailer_lines_are_removed(self):
+        message = (
+            "feat: init\n\nSome body\n\n"
+            "Co-authored-by: Claude <noreply@anthropic.com>\n"
+            "🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+        )
+        out = failed([self.rule()], stdin_text=message)
+        assert out.fix == "feat: init\n\nSome body"
+        assert out.suggest.endswith("Remove the AI trailer lines and re-commit.")
+
+
+class TestBuiltRulesCarryAllowedTypes:
+    """The fix needs the allowed list, so the built-in rules must carry it."""
+
+    def test_default_message_rule_names_the_fix(self):
+        rules = RuleBuilder({"commit": {}}).build_all_rules()
+        message_rules = [r for r in rules if r.check == "message"]
+        out = failed(message_rules, stdin_text="Fix: add x")
+        assert out.fix == "fix: add x"
+        assert out.rule_id == "CC001"
+
+    def test_custom_types_drive_the_fix(self):
+        rules = RuleBuilder({"commit": {"allow_commit_types": ["feat", "fix"]}}).build_all_rules()
+        message_rules = [r for r in rules if r.check == "message"]
+        # "docs" is not allowed here, so it is not a near-miss of anything.
+        out = failed(message_rules, stdin_text="Docs: add x")
+        assert out.fix == ""

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -150,35 +150,44 @@ class TestSignoffFix:
             suggest="Run git commit --signoff",
         )
 
-    @patch("commit_check.engine.get_commit_info", return_value="")
-    @patch("commit_check.engine.get_git_config_value")
-    def test_trailer_uses_local_identity_for_pending_message(self, config, _info):
-        config.side_effect = {
-            "user.name": "Jane Doe",
-            "user.email": "jane@example.com",
-        }.get
+    @patch("commit_check.engine.get_commit_author_identity")
+    @patch("commit_check.engine.get_git_user_identity")
+    def test_trailer_uses_local_identity_for_pending_message(self, config, commit):
+        config.return_value = ("Jane Doe", "jane@example.com")
         out = failed([self.rule()], stdin_text="feat: add x")
         assert out.fix == "feat: add x\n\nSigned-off-by: Jane Doe <jane@example.com>"
         assert out.suggest == (
             'Add the trailer "Signed-off-by: Jane Doe <jane@example.com>" '
             "(git commit --signoff, or --amend --signoff for an existing commit)"
         )
+        # One git call is enough when the config is complete.
+        config.assert_called_once()
+        commit.assert_not_called()
 
-    @patch("commit_check.engine.get_git_config_value", return_value="")
+    @patch("commit_check.engine.get_commit_author_identity")
+    @patch("commit_check.engine.get_git_user_identity")
+    def test_missing_config_part_falls_back_to_the_last_commit(self, config, commit):
+        config.return_value = ("Jane Doe", "")
+        commit.return_value = ("Old Name", "jane@example.com")
+        out = failed([self.rule()], stdin_text="feat: add x")
+        assert out.fix.endswith("Signed-off-by: Jane Doe <jane@example.com>")
+
+    @patch("commit_check.engine.get_git_user_identity")
+    @patch("commit_check.engine.get_commit_author_identity")
     @patch("commit_check.engine.get_commit_info")
-    def test_trailer_uses_commit_author_for_a_revision(self, info, _config):
-        info.side_effect = lambda fmt, rev=None: {
-            "s": "feat: add x",
-            "b": "",
-            "an": "Rev Author",
-            "ae": "rev@example.com",
-        }.get(fmt, "")
+    def test_trailer_uses_commit_author_for_a_revision(self, info, commit, config):
+        info.side_effect = lambda fmt, rev=None: {"s": "feat: add x", "b": ""}.get(
+            fmt, ""
+        )
+        commit.return_value = ("Rev Author", "rev@example.com")
         out = failed([self.rule()], rev="abc123")
         assert out.fix.endswith("Signed-off-by: Rev Author <rev@example.com>")
+        commit.assert_called_once_with("abc123")
+        config.assert_not_called()
 
-    @patch("commit_check.engine.get_commit_info", return_value="")
-    @patch("commit_check.engine.get_git_config_value", return_value="")
-    def test_unknown_identity_keeps_generic_suggestion(self, _config, _info):
+    @patch("commit_check.engine.get_commit_author_identity", return_value=("", ""))
+    @patch("commit_check.engine.get_git_user_identity", return_value=("", ""))
+    def test_unknown_identity_keeps_generic_suggestion(self, _config, _commit):
         out = failed([self.rule()], stdin_text="feat: add x")
         assert out.fix == ""
         assert out.suggest == "Run git commit --signoff"

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -85,6 +85,23 @@ class TestSubjectCapitalizationFix:
         assert out.fix == "feat: Add x"
         assert out.suggest == 'Use "feat: Add x"'
 
+    def test_plain_subject_is_capitalised_and_the_fix_passes_the_rule(self):
+        rule = ValidationRule(
+            check="subject_capitalized",
+            error="Lowercase subject",
+            suggest="Capitalise the subject",
+        )
+        out = failed([rule], stdin_text="add x")
+        assert out.fix == "Add x"
+        # The offered fix must itself satisfy the rule.
+        engine = ValidationEngine([rule])
+        assert (
+            engine.validate_all_detailed(ValidationContext(stdin_text=out.fix))[
+                0
+            ].status
+            == "pass"
+        )
+
 
 class TestWipFix:
     def test_marker_is_dropped(self):
@@ -170,6 +187,11 @@ class TestBranchFix:
             out.suggest
             == 'Rename the branch to "feature/login" (git branch -m feature/login)'
         )
+
+    def test_rename_command_quotes_shell_metacharacters(self):
+        out = failed([self.rule()], stdin_text="Feature/$(whoami)")
+        assert out.fix == "feature/$(whoami)"
+        assert out.suggest.endswith("(git branch -m 'feature/$(whoami)')")
 
     def test_unrelated_prefix_keeps_generic_suggestion(self):
         out = failed([self.rule()], stdin_text="stuff/login")

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -85,6 +85,20 @@ class TestSubjectCapitalizationFix:
         assert out.fix == "feat: Add x"
         assert out.suggest == 'Use "feat: Add x"'
 
+    def test_a_fix_that_would_still_fail_is_withheld(self):
+        """The helper and the validator agree today; the guard is for the day they drift."""
+        rule = ValidationRule(
+            check="subject_capitalized",
+            error="Lowercase subject",
+            suggest="Capitalise the subject",
+        )
+        with patch(
+            "commit_check.engine.fix_subject_case", return_value="still lowercase"
+        ):
+            out = failed([rule], stdin_text="add x")
+        assert out.fix == ""
+        assert out.suggest == "Capitalise the subject"
+
     def test_plain_subject_is_capitalised_and_the_fix_passes_the_rule(self):
         rule = ValidationRule(
             check="subject_capitalized",

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -1502,6 +1502,29 @@ class TestValidationEngine:
         context = ValidationContext(stdin_text="Merge branch 'x' into y")
         assert validator.validate(context) == ValidationResult.SKIP
 
+    @pytest.mark.parametrize(
+        "subject, expected",
+        [
+            ("Add feature", ValidationResult.PASS),
+            ("Update", ValidationResult.PASS),
+            ("add Feature", ValidationResult.FAIL),
+            ("feat(api)!: Drop legacy", ValidationResult.PASS),
+            ("feat(api)!: drop legacy", ValidationResult.FAIL),
+        ],
+    )
+    def test_capitalization_reads_a_plain_subject_from_its_first_word(
+        self, subject, expected
+    ):
+        """Without a colon there is no type: the first word is the description.
+
+        Treating any first word as a type judged "Add feature" on the "f" of
+        "feature" and let "add Feature" through."""
+        rule = ValidationRule(check="subject_capitalized")
+        validator = SubjectCapitalizationValidator(rule)
+        validator._suppress_output = True
+        context = ValidationContext(stdin_text=subject)
+        assert validator.validate(context) == expected
+
     def test_capitalization_judges_a_subject_that_merely_mentions_merge(self):
         """Only git's exact "Merge " prefix is machine-written; a subject
         that happens to start with the word in lowercase is author prose."""

--- a/tests/fixes_test.py
+++ b/tests/fixes_test.py
@@ -139,15 +139,22 @@ class TestFixBranchType:
 
 class TestStripLinesContaining:
     def test_drops_matching_lines_only(self):
-        message = "feat: init\n\nSome body\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+        message = (
+            "feat: init\n\nSome body\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+        )
         assert (
-            strip_lines_containing(message, ["Co-authored-by: Claude <noreply@anthropic.com>"])
+            strip_lines_containing(
+                message, ["Co-authored-by: Claude <noreply@anthropic.com>"]
+            )
             == "feat: init\n\nSome body"
         )
 
     def test_partial_fragment_matches_its_line(self):
         message = "feat: init\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
-        assert strip_lines_containing(message, ["🤖 Generated with [Claude"]) == "feat: init"
+        assert (
+            strip_lines_containing(message, ["🤖 Generated with [Claude"])
+            == "feat: init"
+        )
 
     def test_no_match_no_fix(self):
         assert strip_lines_containing("feat: init", ["Co-authored-by: Claude"]) is None
@@ -155,4 +162,7 @@ class TestStripLinesContaining:
         assert strip_lines_containing("feat: init", [""]) is None
 
     def test_nothing_left_is_no_fix(self):
-        assert strip_lines_containing("Co-authored-by: Claude", ["Co-authored-by: Claude"]) is None
+        assert (
+            strip_lines_containing("Co-authored-by: Claude", ["Co-authored-by: Claude"])
+            is None
+        )

--- a/tests/fixes_test.py
+++ b/tests/fixes_test.py
@@ -124,7 +124,7 @@ class TestSignoffTrailer:
 class TestFixBranchType:
     def test_case_and_spelling(self):
         assert fix_branch_type("Feature/login", TYPES + ["feature"]) == "feature/login"
-        assert fix_branch_type("featre/login", ["feature", "bugfix"]) == "feature/login"
+        assert fix_branch_type("bugfx/login", ["feature", "bugfix"]) == "bugfix/login"
 
     def test_no_slash_no_fix(self):
         assert fix_branch_type("login", ["feature"]) is None

--- a/tests/fixes_test.py
+++ b/tests/fixes_test.py
@@ -1,0 +1,158 @@
+"""Tests for the deterministic corrections in commit_check.fixes."""
+
+import pytest
+
+from commit_check.fixes import (
+    fix_branch_type,
+    fix_conventional_header,
+    fix_subject_case,
+    fix_wip,
+    signoff_trailer,
+    strip_lines_containing,
+)
+
+TYPES = ["feat", "fix", "docs", "test", "chore", "refactor"]
+
+
+class TestFixConventionalHeader:
+    @pytest.mark.parametrize(
+        "subject, expected",
+        [
+            ("Fix: add x", "fix: add x"),
+            ("FEAT(api): add x", "feat(api): add x"),
+            ("feat add x", "feat: add x"),
+            ("feat:add x", "feat: add x"),
+            ("feat :  add x", "feat: add x"),
+            ("feta: add x", "feat: add x"),
+            ("refactr(core)!: drop y", "refactor(core)!: drop y"),
+            ("  fix: trailing  ", "fix: trailing"),
+        ],
+    )
+    def test_mechanical_slips_are_corrected(self, subject, expected):
+        assert fix_conventional_header(subject, TYPES) == expected
+
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            "add x",  # no type at all: choosing one is a judgment
+            "update the readme",  # a verb, not a near-miss of a type
+            "feat: add x",  # already valid, nothing to change
+            "feat:",  # no description to keep
+            "xyzzy: add x",  # not close to any type
+        ],
+    )
+    def test_declines_to_guess(self, subject):
+        assert fix_conventional_header(subject, TYPES) is None
+
+    def test_no_allowed_types_no_fix(self):
+        assert fix_conventional_header("Fix: add x", None) is None
+        assert fix_conventional_header("Fix: add x", []) is None
+
+    def test_short_words_only_match_by_case(self):
+        # "fx" is one letter off "fix" but too short for similarity matching.
+        assert fix_conventional_header("fx: add x", TYPES) is None
+        assert fix_conventional_header("FIX: add x", TYPES) == "fix: add x"
+
+    def test_feat_never_becomes_test(self):
+        # Both are four letters and share two; the cutoff must keep them apart.
+        assert fix_conventional_header("feat: add x", ["test"]) is None
+        # A one-letter substitution in a short word is a different word.
+        assert fix_conventional_header("text: add x", ["test"]) is None
+
+    def test_swapped_letters_are_corrected(self):
+        assert fix_conventional_header("feta: add x", TYPES) == "feat: add x"
+        assert fix_conventional_header("fxi: add x", TYPES) == "fix: add x"
+
+
+class TestFixSubjectCase:
+    def test_capitalizes_description_after_prefix(self):
+        assert fix_subject_case("feat: add x") == "feat: Add x"
+        assert fix_subject_case("fix(api)!: drop y") == "fix(api)!: Drop y"
+
+    def test_capitalizes_plain_subject(self):
+        assert fix_subject_case("add x") == "Add x"
+
+    def test_lowercases_when_asked(self):
+        assert fix_subject_case("feat: Add x", capitalize=False) == "feat: add x"
+
+    def test_no_change_needed(self):
+        assert fix_subject_case("feat: Add x") is None
+
+    def test_non_alphabetic_start_is_not_touched(self):
+        assert fix_subject_case("feat: 2fa support") is None
+        assert fix_subject_case("feat: ") is None
+
+
+class TestFixWip:
+    @pytest.mark.parametrize(
+        "message, expected",
+        [
+            ("WIP: add x", "add x"),
+            ("wip: add x", "add x"),
+            ("[WIP] add x", "add x"),
+            ("[wip]: add x", "add x"),
+            ("WIP add x", "add x"),
+            ("WIP - add x", "add x"),
+            ("WIP: feat: add x\n\nbody", "feat: add x\n\nbody"),
+        ],
+    )
+    def test_marker_is_dropped(self, message, expected):
+        assert fix_wip(message) == expected
+
+    def test_nothing_left_is_no_fix(self):
+        assert fix_wip("WIP") is None
+        assert fix_wip("WIP:") is None
+
+    def test_no_marker_no_fix(self):
+        assert fix_wip("feat: add x") is None
+        # "wipe" is a word, not a marker.
+        assert fix_wip("wipe the cache") is None
+
+
+class TestSignoffTrailer:
+    def test_full_identity(self):
+        assert (
+            signoff_trailer("Jane Doe", "jane@example.com")
+            == "Signed-off-by: Jane Doe <jane@example.com>"
+        )
+
+    def test_missing_half_is_no_trailer(self):
+        assert signoff_trailer("", "jane@example.com") is None
+        assert signoff_trailer("Jane Doe", "") is None
+
+
+class TestFixBranchType:
+    def test_case_and_spelling(self):
+        assert fix_branch_type("Feature/login", TYPES + ["feature"]) == "feature/login"
+        assert fix_branch_type("featre/login", ["feature", "bugfix"]) == "feature/login"
+
+    def test_no_slash_no_fix(self):
+        assert fix_branch_type("login", ["feature"]) is None
+        assert fix_branch_type("feature/", ["feature"]) is None
+
+    def test_unrelated_prefix_no_fix(self):
+        assert fix_branch_type("xyzzy/login", ["feature", "bugfix"]) is None
+
+    def test_already_valid_no_fix(self):
+        assert fix_branch_type("feature/login", ["feature"]) is None
+
+
+class TestStripLinesContaining:
+    def test_drops_matching_lines_only(self):
+        message = "feat: init\n\nSome body\n\nCo-authored-by: Claude <noreply@anthropic.com>"
+        assert (
+            strip_lines_containing(message, ["Co-authored-by: Claude <noreply@anthropic.com>"])
+            == "feat: init\n\nSome body"
+        )
+
+    def test_partial_fragment_matches_its_line(self):
+        message = "feat: init\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+        assert strip_lines_containing(message, ["🤖 Generated with [Claude"]) == "feat: init"
+
+    def test_no_match_no_fix(self):
+        assert strip_lines_containing("feat: init", ["Co-authored-by: Claude"]) is None
+        assert strip_lines_containing("feat: init", []) is None
+        assert strip_lines_containing("feat: init", [""]) is None
+
+    def test_nothing_left_is_no_fix(self):
+        assert strip_lines_containing("Co-authored-by: Claude", ["Co-authored-by: Claude"]) is None

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -3,6 +3,7 @@ import os
 import sys
 import pytest
 import subprocess
+from unittest.mock import patch
 import commit_check
 from commit_check import supports_color
 from commit_check.util import (
@@ -1419,3 +1420,29 @@ class TestParseSizeOverflow:
         assert parse_size("inf") is None
         assert parse_size("1e999MB") is None
         assert parse_size("nan") is None
+
+
+class TestIdentityLookups:
+    """Both identity helpers ask git exactly once."""
+
+    @patch("commit_check.util.cmd_output")
+    def test_git_user_identity_parses_both_keys(self, cmd):
+        from commit_check.util import get_git_user_identity
+
+        cmd.return_value = "user.name Jane Doe\nuser.email jane@example.com\n"
+        assert get_git_user_identity() == ("Jane Doe", "jane@example.com")
+        cmd.assert_called_once()
+
+    @patch("commit_check.util.cmd_output", return_value="user.email jane@example.com\n")
+    def test_git_user_identity_leaves_missing_parts_blank(self, _cmd):
+        from commit_check.util import get_git_user_identity
+
+        assert get_git_user_identity() == ("", "jane@example.com")
+
+    @patch("commit_check.util.cmd_output", return_value="Jane Doe\x1fjane@example.com")
+    def test_commit_author_identity_splits_the_record(self, cmd):
+        from commit_check.util import get_commit_author_identity
+
+        assert get_commit_author_identity("abc") == ("Jane Doe", "jane@example.com")
+        assert "--pretty=format:%an%x1f%ae" in cmd.call_args[0][0]
+        assert cmd.call_args[0][0][-1] == "abc"


### PR DESCRIPTION
## What

A failed check used to carry the same generic suggestion whatever the message looked like. `Fix: add x` got the full Conventional Commits recipe even though the only thing wrong was the capital F. Most failures in practice are mechanical slips like that, and both people and agents were left to work out the obvious.

Validators now name the correction when it can be derived without a guess, and keep the generic text when it cannot.

| Rule | Before | After |
|---|---|---|
| CC001 `message` on `Fix: add x` | `Use <type>(<scope>): <description>, where <type> is one of: …` | `Use "fix: add x"` |
| CC001 on `feta(api): add x` | same generic text | `Use "feat(api): add x"` |
| CC001 on `docs update readme` | same generic text | `Use "docs: update readme"` |
| CC002 `subject_capitalized` on `feat: add x` | `Capitalize the first letter…` | `Use "feat: Add x"` |
| CC010 `allow_wip_commits` on `WIP: feat: add x` | `Finish the work…` | `Drop the WIP marker: "feat: add x"` |
| CC012 `require_signed_off_by` | `git commit --amend --signoff or use --signoff on commit` | `Add the trailer "Signed-off-by: Jane Doe <jane@example.com>" (git commit --signoff, or --amend --signoff for an existing commit)` |
| CC201 `branch` on `Feature/login` | `Use type/description` | `Rename the branch to "feature/login" (git branch -m feature/login)` |
| CC013 `ai_attribution` | `Remove AI trailers and re-commit.` | same wording, plus the message with the matched lines removed as the fix |
| CC001 on `add x` (no type) | generic | **unchanged**: choosing a type is a judgment |

## How

- New `commit_check/fixes.py`: pure, git-free functions. Type matching forgives case, one swapped pair of adjacent letters, and a one-letter slip by similarity, with a cutoff tight enough that `feat` never becomes `test` and `text` never becomes `test`. Words under three letters match by case only.
- The corrected header/branch must itself satisfy the rule's regex, or no fix is offered. No type is ever invented.
- `CheckOutcome` gains a `fix` field, serialised in `--format json` and the Python API. `suggest` is rewritten to name the fix, so consumers that only print `suggest` (the GitHub App, the Action, pre-commit output) get the better wording with no change on their side. Agents (MCP) can apply `fix` directly.
- The sign-off trailer uses the same identity resolution modes as the author checks (pending message → local git config; `--rev` → that commit's author).

## Not in scope

Fixes that take a judgment stay generic: a bare subject with no type, a subject over the length limit, a non-imperative verb. Per-rule warn level is a separate follow-up.

## Tests

- `tests/fixes_test.py`: the pure functions, including the near-miss boundaries.
- `tests/engine_fixes_test.py`: end-to-end through `ValidationEngine.validate_all_detailed` for every rule above, plus the built-in default rules carrying `allowed` types.
- Full suite: 752 passed. The one failure, `test_load_config_file_permission_error`, is pre-existing and only fails when running as root.
- `pre-commit run --all-files` clean (ruff, mypy, codespell).

README JSON samples and the API schema now show the `fix` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic corrections for common commit validation issues, including header formatting, subject capitalization, WIP markers, sign-off trailers, branch prefixes, and AI-attribution lines.
  - Validation results now include a suggested corrected value when a safe, unambiguous fix is available.

- **Documentation**
  - Updated the README and API documentation with the new correction field and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->