### PR TITLE
feat: report a rule without enforcing it with a top-level warn list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Commit Check can be configured in three ways (in order of priority):
 To customize the behavior, create a configuration file named `cchk.toml` or `commit-check.toml` in your repository's root directory or in the `.github` folder, e.g., [`cchk.toml`](https://github.com/commit-check/commit-check/blob/main/cchk.toml) or `.github/cchk.toml`.
 
 ```toml
+# Rules to report without enforcing: they print in full, never fail the run.
+# Name a check or its rule ID. See "Report a rule without enforcing it" below.
+warn = ["branch"]
+
 [commit]
 # https://www.conventionalcommits.org
 conventional_commits = true
@@ -155,6 +159,24 @@ allow_branch_types = [
 > so editors like VS Code (via [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml)),
 > PyCharm, and IntelliJ provide autocompletion, validation, and documentation
 > tooltips for `cchk.toml` out of the box — no manual schema path configuration needed.
+
+### Report a rule without enforcing it
+
+A rule is normally on or off. `warn` gives it a third setting: run, report
+the finding in full, and never fail the run. Name a check or its rule ID:
+
+```toml
+warn = ["branch", "CC003"]
+```
+
+A warned rule prints the same block as a failure with `warning` in place of
+`failed`, no rejection banner, and one closing line saying the run is not
+failed by it. The exit code counts only enforced rules, and in `--format json`
+the check's `status` is `warn`, the top-level `status` stays `pass`, and
+`warnings` counts them. This is how a team adopts a rule gradually: turn it on
+as a warning, watch what it catches, then drop it from `warn` when the history
+is clean. A name that matches no rule is a configuration error, so a typo
+cannot leave a rule silently enforced.
 
 ### Organization-Level Configuration (inherit_from)
 
@@ -326,6 +348,7 @@ echo "feat: add streaming support" | commit-check -m --format json
 ```json
 {
   "status": "pass",
+  "warnings": 0,
   "checks": [
     {
       "rule_id": "CC001",
@@ -371,6 +394,7 @@ echo "wip bad commit" | commit-check -m --format json
 ```json
 {
   "status": "fail",
+  "warnings": 0,
   "checks": [
     {
       "rule_id": "CC001",
@@ -422,6 +446,7 @@ echo "Fix: add streaming support" | commit-check -m --format json
 ```json
 {
   "status": "fail",
+  "warnings": 0,
   "checks": [
     {
       "rule_id": "CC001",
@@ -512,11 +537,12 @@ print(result["status"])          # "fail" — 'docs' not in allowed types
 ```python
 {
     "status": "pass" | "fail" | "skip",
+    "warnings": <number of checks with status "warn">,
     "checks": [
         {
             "rule_id":  "<rule identifier, e.g. CC001>",
             "check":    "<rule name>",
-            "status":   "pass" | "fail" | "skip",
+            "status":   "pass" | "fail" | "warn" | "skip",
             "value":    "<actual value that was checked>",
             "error":    "<human-readable error description>",
             "suggest":  "<how to fix>",
@@ -528,8 +554,10 @@ print(result["status"])          # "fail" — 'docs' not in allowed types
 }
 ```
 
-`skip` means the rule never ran — the author matched `ignore_authors`, or
-there was nothing to check. It is deliberately not `pass`: a skipped rule
+`warn` means the rule was not satisfied but is listed under `warn` in the
+config: the finding is reported and does not fail the run, and `warnings`
+counts these. `skip` means the rule never ran — the author matched
+`ignore_authors`, or there was nothing to check. It is deliberately not `pass`: a skipped rule
 validated nothing, so reporting it as a pass makes a bypassed policy
 indistinguishable from an enforced one. A skipped check carries no `value`,
 since nothing was examined.
@@ -546,6 +574,7 @@ echo "chore(deps): bump commit-check" | CCHK_IGNORE_AUTHORS="dependabot[bot]" co
 ```json
 {
   "status": "skip",
+  "warnings": 0,
   "checks": [
     {
       "rule_id": "CC001",

--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ warn = ["branch", "CC003"]
 
 A warned rule prints the same block as a failure with `warning` in place of
 `failed`, no rejection banner, and one closing line saying the run is not
-failed by it. The exit code counts only enforced rules, and in `--format json`
-the check's `status` is `warn`, the top-level `status` stays `pass`, and
-`warnings` counts them. This is how a team adopts a rule gradually: turn it on
+failed by it; with `--compact` it is one `[WARN]` line. The exit code counts
+only enforced rules, and in `--format json` the check's `status` is `warn`, the
+top-level `status` stays `pass`, and `warnings` counts them. This is how a team
+adopts a rule gradually: turn it on
 as a warning, watch what it catches, then drop it from `warn` when the history
 is clean. A name that matches no rule is a configuration error, so a typo
 cannot leave a rule silently enforced.

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -20,10 +20,11 @@ Return-value schema (all functions)::
 
     {
         "status": "pass" | "fail" | "skip",
+        "warnings": <number of checks with status "warn">,
         "checks": [
             {
                 "check":   "<rule name>",
-                "status":  "pass" | "fail" | "skip",
+                "status":  "pass" | "fail" | "warn" | "skip",
                 "value":   "<actual value that was checked>",
                 "error":   "<error description>",
                 "suggest": "<how to fix>",
@@ -52,6 +53,7 @@ from commit_check.engine import (
     CheckOutcome,
     ValidationContext,
     ValidationEngine,
+    count_warnings,
     overall_status,
 )
 from commit_check.rule_builder import RuleBuilder
@@ -67,6 +69,7 @@ def _build_result(outcomes: list[CheckOutcome]) -> dict[str, Any]:
     public return-value dict."""
     return {
         "status": overall_status(o.status for o in outcomes),
+        "warnings": count_warnings(o.status for o in outcomes),
         "checks": [o.to_dict() for o in outcomes],
     }
 
@@ -292,7 +295,11 @@ def validate_author(
         # Shared reducer, not a local "fail or else pass": a combined call
         # in which every nested check skipped is still a skip.
         overall = overall_status(c["status"] for c in all_checks)
-        return {"status": overall, "checks": all_checks}
+        return {
+            "status": overall,
+            "warnings": count_warnings(c["status"] for c in all_checks),
+            "checks": all_checks,
+        }
 
     stdin = None
     if name is not None:
@@ -350,4 +357,8 @@ def validate_all(
         all_checks.extend(author_result["checks"])
 
     overall = overall_status(c["status"] for c in all_checks)
-    return {"status": overall, "checks": all_checks}
+    return {
+        "status": overall,
+        "warnings": count_warnings(c["status"] for c in all_checks),
+        "checks": all_checks,
+    }

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -118,7 +118,8 @@ def validate_message(
         If *None*, built-in defaults are used.  You can pass a partial dict to
         override only the keys you care about, e.g.
         ``{"commit": {"allow_commit_types": ["feat", "fix"]}}``.
-    :returns: A dict with ``"status"`` (``"pass"``/``"fail"``) and ``"checks"``
+    :returns: A dict with ``"status"`` (``"pass"``/``"fail"``/``"skip"``), a
+        ``"warnings"`` count and ``"checks"``
         (list of per-rule outcomes).
 
     Example::
@@ -159,7 +160,7 @@ def validate_branch(
     :param branch: Branch name to validate.  If *None*, the current git branch
         is used (via ``git branch --show-current``).
     :param config: Optional configuration override dict.
-    :returns: A dict with ``"status"`` and ``"checks"``.
+    :returns: A dict with ``"status"``, a ``"warnings"`` count and ``"checks"``.
 
     Example::
 
@@ -192,7 +193,7 @@ def validate_tag(
     :param config: Optional configuration override dict. The pattern comes
         from ``config["tag"]["regex"]`` and defaults to SemVer with an
         optional leading ``v`` (``v1.2.3`` or ``1.2.3``).
-    :returns: A dict with ``"status"`` and ``"checks"``.
+    :returns: A dict with ``"status"``, a ``"warnings"`` count and ``"checks"``.
 
     Example::
 
@@ -225,9 +226,11 @@ def validate_push(
         pre-push hook: ``<local ref> <local sha1> <remote ref> <remote sha1>``,
         one entry per line.  If *None*, the check is skipped (returns pass).
     :param config: Optional configuration override dict.  The push check is
-        always enabled when calling this function; force pushes detected here
-        will always return ``"fail"``.
-    :returns: A dict with ``"status"`` (``"pass"``/``"fail"``) and ``"checks"``.
+        always enabled when calling this function; a detected force push fails
+        the result unless ``no_force_push`` is listed under ``warn``, in which
+        case the check reports ``"warn"`` and the result passes.
+    :returns: A dict with ``"status"`` (``"pass"``/``"fail"``/``"skip"``), a
+        ``"warnings"`` count and ``"checks"``.
 
     Example::
 
@@ -259,7 +262,7 @@ def validate_author(
     :param email: Author email to validate.  If *None*, the value from
         ``git config user.email`` is used.
     :param config: Optional configuration override dict.
-    :returns: A dict with ``"status"`` and ``"checks"``.
+    :returns: A dict with ``"status"``, a ``"warnings"`` count and ``"checks"``.
 
     Example::
 
@@ -329,8 +332,8 @@ def validate_all(
     :param author_name: Author name to validate, or *None* to skip.
     :param author_email: Author email to validate, or *None* to skip.
     :param config: Optional configuration override dict.
-    :returns: A dict with ``"status"`` and ``"checks"`` combining all requested
-        validations.
+    :returns: A dict with ``"status"``, a ``"warnings"`` count and ``"checks"``
+        combining all requested validations.
 
     Example::
 

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -97,9 +97,11 @@ class CheckOutcome:
 
     check: str
     # "pass" (the rule ran and was satisfied), "fail" (the rule ran and was
-    # not), or "skip" (the rule never ran — ignored author, or nothing to
-    # check). A skip is not a pass: it means the policy was bypassed, and
-    # collapsing the two lets a run that validated nothing report success.
+    # not), "warn" (the rule was not satisfied but is listed under ``warn``
+    # in the config, so it is reported and does not fail the run), or "skip"
+    # (the rule never ran — ignored author, or nothing to check). A skip is
+    # not a pass: it means the policy was bypassed, and collapsing the two
+    # lets a run that validated nothing report success.
     status: str
     # The concrete value that was checked (subject, branch, author, ...),
     # populated on both pass and fail so consumers can report what was
@@ -143,7 +145,9 @@ def overall_status(statuses: Iterable[str]) -> str:
     after the skip status existed.
 
     ``"skip"`` requires that *every* check skipped: a single real verdict
-    means something was actually validated. Only ``"fail"`` is an error.
+    means something was actually validated. Only ``"fail"`` is an error: a
+    ``"warn"`` is a verdict the config asked to report without enforcing,
+    so a run whose only findings are warnings passes.
     """
     seen = list(statuses)
     if any(s == "fail" for s in seen):
@@ -151,6 +155,11 @@ def overall_status(statuses: Iterable[str]) -> str:
     if seen and all(s == "skip" for s in seen):
         return "skip"
     return "pass"
+
+
+def count_warnings(statuses: Iterable[str]) -> int:
+    """How many checks were reported as warnings rather than failures."""
+    return sum(1 for s in statuses if s == "warn")
 
 
 class BaseValidator(ABC):
@@ -1396,8 +1405,9 @@ class ValidationEngine:
 
     def validate_all(self, context: ValidationContext) -> ValidationResult:
         """Run all validations and return overall result."""
-        results = []
+        failed = False
         skipped: list[str] = []
+        warned: list[str] = []
 
         for rule in self.rules:
             validator_class = self.VALIDATOR_MAP.get(rule.check)
@@ -1408,9 +1418,13 @@ class ValidationEngine:
             validator._no_banner = context.no_banner
             validator._compact = context.compact
             result = validator.validate(context)
-            results.append(result)
             if result == ValidationResult.SKIP:
                 skipped.append(rule.check.replace("_", "-"))
+            elif result == ValidationResult.FAIL:
+                if rule.severity == "warn":
+                    warned.append(rule.check.replace("_", "-"))
+                else:
+                    failed = True
 
         if skipped:
             # A skipped check validated nothing, and a silent skip is
@@ -1424,12 +1438,19 @@ class ValidationEngine:
                 file=sys.stderr,
             )
 
-        # Return FAIL if any validation failed
-        return (
-            ValidationResult.FAIL
-            if ValidationResult.FAIL in results
-            else ValidationResult.PASS
-        )
+        if warned:
+            # A warning was printed in full above; this one line says why the
+            # run still passes, so a hook that exits 0 after red-looking output
+            # is not mistaken for a broken hook.
+            import sys
+
+            print(
+                f"⚠ warnings (not enforced): {', '.join(warned)}",
+                file=sys.stderr,
+            )
+
+        # Only an enforced rule fails the run; a warning is reported and done.
+        return ValidationResult.FAIL if failed else ValidationResult.PASS
 
     def validate_all_detailed(self, context: ValidationContext) -> list[CheckOutcome]:
         """Run all validations and return structured :class:`CheckOutcome` objects.
@@ -1463,7 +1484,7 @@ class ValidationEngine:
                 outcomes.append(
                     CheckOutcome(
                         check=rule.check,
-                        status="fail",
+                        status="warn" if rule.severity == "warn" else "fail",
                         value=failure.get("value", ""),
                         error=failure.get("error", ""),
                         suggest=failure.get("suggest", ""),

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -13,6 +13,7 @@ from commit_check.engine import (
     ValidationContext,
     ValidationResult,
     CheckOutcome,
+    count_warnings,
     overall_status,
 )
 from . import __version__
@@ -569,6 +570,7 @@ def _run_json_output(engine: ValidationEngine, context: ValidationContext) -> in
         json.dumps(
             {
                 "status": overall,
+                "warnings": count_warnings(o.status for o in outcomes),
                 "checks": [o.to_dict() for o in outcomes],
             },
             indent=2,

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -103,8 +103,8 @@ class RuleBuilder:
     def _resolve_warn_list(names: Any) -> frozenset[str]:
         """The checks the top-level ``warn`` list demotes to warnings.
 
-        Entries name a check (``branch``) or a rule ID (``CC201``). A name
-        nothing matches is refused rather than ignored: a typo that silently
+        Entries name a check (``branch``) or a rule ID (``CC201``), in any
+        case. A name nothing matches is refused rather than ignored: a typo that silently
         left the rule enforcing would be discovered by whoever it blocked.
         """
         if names is None:
@@ -115,6 +115,7 @@ class RuleBuilder:
             raise ValueError(
                 'warn must be a list of rule names, e.g. warn = ["branch"]'
             )
+        by_check = {check.lower(): check for check in RULES_BY_CHECK}
         by_id = {
             entry.rule_id.lower(): entry.check
             for entry in RULES_BY_CHECK.values()
@@ -122,11 +123,11 @@ class RuleBuilder:
         }
         resolved = set()
         for name in names:
-            key = name.strip()
-            if key in RULES_BY_CHECK:
-                resolved.add(key)
-            elif key.lower() in by_id:
-                resolved.add(by_id[key.lower()])
+            key = name.strip().lower()
+            if key in by_check:
+                resolved.add(by_check[key])
+            elif key in by_id:
+                resolved.add(by_id[key])
             else:
                 known = ", ".join(sorted(RULES_BY_CHECK))
                 raise ValueError(

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 import sys
 from typing import Any
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from commit_check.rules_catalog import (
     COMMIT_RULES,
     BRANCH_RULES,
@@ -35,6 +35,9 @@ class ValidationRule:
     value: Any = None
     allowed: list[str] | None = None
     ignored: list[str] | None = None
+    # "error" fails the run; "warn" is reported in full but never fails it.
+    # Set from the top-level ``warn`` list in the config.
+    severity: str = "error"
 
     @property
     def rule_id(self) -> str | None:
@@ -55,6 +58,7 @@ class ValidationRule:
             "regex": self.regex or "",
             "error": self.error or "",
             "suggest": self.suggest or "",
+            "severity": self.severity,
         }
         if self.rule_id:
             result["rule_id"] = self.rule_id
@@ -80,6 +84,7 @@ class RuleBuilder:
         self.push_config = config.get("push", {})
         self.tag_config = config.get("tag", {})
         self.files_config = config.get("files", {})
+        self.warn_checks = self._resolve_warn_list(config.get("warn", []))
 
     def build_all_rules(self) -> list[ValidationRule]:
         """Build all validation rules from config."""
@@ -89,7 +94,45 @@ class RuleBuilder:
         rules.extend(self._build_push_rules())
         rules.extend(self._build_files_rules())
         rules.extend(self._build_tag_rules())
-        return rules
+        return [
+            replace(rule, severity="warn") if rule.check in self.warn_checks else rule
+            for rule in rules
+        ]
+
+    @staticmethod
+    def _resolve_warn_list(names: Any) -> frozenset[str]:
+        """The checks the top-level ``warn`` list demotes to warnings.
+
+        Entries name a check (``branch``) or a rule ID (``CC201``). A name
+        nothing matches is refused rather than ignored: a typo that silently
+        left the rule enforcing would be discovered by whoever it blocked.
+        """
+        if names is None:
+            return frozenset()
+        if isinstance(names, str):
+            names = [names]
+        if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+            raise ValueError(
+                'warn must be a list of rule names, e.g. warn = ["branch"]'
+            )
+        by_id = {
+            entry.rule_id.lower(): entry.check
+            for entry in RULES_BY_CHECK.values()
+            if entry.rule_id
+        }
+        resolved = set()
+        for name in names:
+            key = name.strip()
+            if key in RULES_BY_CHECK:
+                resolved.add(key)
+            elif key.lower() in by_id:
+                resolved.add(by_id[key.lower()])
+            else:
+                known = ", ".join(sorted(RULES_BY_CHECK))
+                raise ValueError(
+                    f"warn names an unknown rule {name!r}. Known rules: {known}"
+                )
+        return frozenset(resolved)
 
     def _build_commit_rules(self) -> list[ValidationRule]:
         """Build commit-related validation rules."""

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -24,6 +24,16 @@ from commit_check import (
 )
 
 
+# Lookup tables for the top-level ``warn`` list, built once at import: a
+# check name or rule ID in any case maps to the catalog's check name.
+_CHECKS_BY_LOWER_NAME = {check.lower(): check for check in RULES_BY_CHECK}
+_CHECKS_BY_LOWER_ID = {
+    entry.rule_id.lower(): entry.check
+    for entry in RULES_BY_CHECK.values()
+    if entry.rule_id
+}
+
+
 @dataclass(frozen=True)
 class ValidationRule:
     """A complete validation rule with all necessary information."""
@@ -94,6 +104,8 @@ class RuleBuilder:
         rules.extend(self._build_push_rules())
         rules.extend(self._build_files_rules())
         rules.extend(self._build_tag_rules())
+        if not self.warn_checks:
+            return rules
         return [
             replace(rule, severity="warn") if rule.check in self.warn_checks else rule
             for rule in rules
@@ -107,7 +119,9 @@ class RuleBuilder:
         case. A name nothing matches is refused rather than ignored: a typo that silently
         left the rule enforcing would be discovered by whoever it blocked.
         """
-        if names is None:
+        # The common config lists nothing, and the builder runs once per
+        # check; that path pays for nothing here.
+        if not names:
             return frozenset()
         if isinstance(names, str):
             names = [names]
@@ -115,19 +129,13 @@ class RuleBuilder:
             raise ValueError(
                 'warn must be a list of rule names, e.g. warn = ["branch"]'
             )
-        by_check = {check.lower(): check for check in RULES_BY_CHECK}
-        by_id = {
-            entry.rule_id.lower(): entry.check
-            for entry in RULES_BY_CHECK.values()
-            if entry.rule_id
-        }
         resolved = set()
         for name in names:
             key = name.strip().lower()
-            if key in by_check:
-                resolved.add(by_check[key])
-            elif key in by_id:
-                resolved.add(by_id[key])
+            if key in _CHECKS_BY_LOWER_NAME:
+                resolved.add(_CHECKS_BY_LOWER_NAME[key])
+            elif key in _CHECKS_BY_LOWER_ID:
+                resolved.add(_CHECKS_BY_LOWER_ID[key])
             else:
                 known = ", ".join(sorted(RULES_BY_CHECK))
                 raise ValueError(

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -20,15 +20,22 @@ def _print_failure(
     no_banner: bool = False,
     compact: bool = False,
 ) -> None:
-    """Print a standardized failure message."""
+    """Print a standardized failure message.
+
+    A rule whose ``severity`` is ``"warn"`` prints the same block with the
+    word ``warning`` in place of ``failed``, no rejection banner, and one
+    closing line saying the run is not failed by it.
+    """
     rule_id = check.get("rule_id", "")
+    warn = check.get("severity") == "warn"
     if compact:
         compact_value = actual.splitlines()[0] if actual else actual
         name = display_name(check["check"])
         label = f"{rule_id} {name}" if rule_id else name
-        print(f"[FAIL] {label}: {compact_value}")
+        print(f"[{'WARN' if warn else 'FAIL'}] {label}: {compact_value}")
         return
-    if not no_banner and not print_error_header.has_been_called:
+    # The banner announces a rejected commit; a warning rejects nothing.
+    if not warn and not no_banner and not print_error_header.has_been_called:
         print_error_header()
     docs_url = check.get("docs_url", "") or ""
     print_error_message(
@@ -37,6 +44,7 @@ def _print_failure(
         actual,
         rule_id=rule_id,
         docs_url=docs_url,
+        warn=warn,
     )
     if check.get("suggest"):
         print_suggestion(check["suggest"])
@@ -45,6 +53,8 @@ def _print_failure(
     # way the reader gets the address at all, so it stays.
     if docs_url and not (rule_id and supports_hyperlinks()):
         print(f"Docs: {docs_url}")
+    if warn:
+        print("This rule is set to warn in the config; it does not fail the run.")
     # Blank line closes the whole block, rather than splitting it before the
     # documentation link.
     print()
@@ -641,6 +651,7 @@ def print_error_message(
     reason: str,
     rule_id: str = "",
     docs_url: str = "",
+    warn: bool = False,
 ) -> None:
     """Print error message.
 
@@ -650,6 +661,8 @@ def print_error_message(
     :param rule_id: stable rule ID, e.g. ``CC003`` (omitted when empty)
     :param docs_url: the rule's documentation, linked from the ID when the
         terminal supports it
+    :param warn: the rule is reported, not enforced: say ``warning`` rather
+        than ``failed``, and colour the value as a caution, not an error
 
     :returns: Give error messages to user
     """
@@ -658,8 +671,9 @@ def print_error_message(
     if rule_id and docs_url and supports_hyperlinks():
         label = hyperlink(rule_id, docs_url)
     prefix = f"{YELLOW}{label}{RESET_COLOR} " if rule_id else ""
+    verdict, colour = ("warning", YELLOW) if warn else ("failed", RED)
     print(
-        f"{prefix}{YELLOW}{name}{RESET_COLOR} check failed ==> {RED}{reason}{RESET_COLOR}"
+        f"{prefix}{YELLOW}{name}{RESET_COLOR} check {verdict} ==> {colour}{reason}{RESET_COLOR}"
     )
     if error:
         print(error)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -520,3 +520,26 @@ class TestValidateTag:
         """An explicit empty string names an empty tag list, not HEAD."""
         result = validate_tag("")
         assert result["status"] == "skip"
+
+
+class TestWarnLevelInTheApi:
+    def test_warned_rule_does_not_fail_the_message(self):
+        from commit_check.api import validate_message
+
+        result = validate_message(
+            "feat: added x",
+            config={
+                "warn": ["subject_imperative"],
+                "commit": {"subject_imperative": True},
+            },
+        )
+        assert result["status"] == "pass"
+        assert result["warnings"] == 1
+        by_check = {c["check"]: c["status"] for c in result["checks"]}
+        assert by_check["subject_imperative"] == "warn"
+
+    def test_every_result_carries_a_warnings_count(self):
+        from commit_check.api import validate_message
+
+        result = validate_message("feat: add x")
+        assert result["warnings"] == 0

--- a/tests/engine_fixes_test.py
+++ b/tests/engine_fixes_test.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import patch
 
-from commit_check.engine import ValidationContext, ValidationEngine
+from commit_check.engine import (
+    ValidationContext,
+    ValidationEngine,
+    ValidationResult,
+    count_warnings,
+    overall_status,
+)
 from commit_check.rule_builder import RuleBuilder, ValidationRule
 
 CONVENTIONAL = (
@@ -260,3 +266,70 @@ class TestBuiltRulesCarryAllowedTypes:
         # "docs" is not allowed here, so it is not a near-miss of anything.
         out = failed(message_rules, stdin_text="Docs: add x")
         assert out.fix == ""
+
+
+class TestWarnSeverityInTheEngine:
+    """A rule listed under ``warn`` is reported like a failure and counted like a pass."""
+
+    def rules(self):
+        return [
+            ValidationRule(
+                check="message", regex=CONVENTIONAL, error="e1", suggest="s1"
+            ),
+            ValidationRule(
+                check="subject_imperative",
+                error="Not imperative",
+                suggest="Use the imperative",
+                severity="warn",
+            ),
+        ]
+
+    def test_detailed_outcome_is_warn_not_fail(self):
+        outcomes = ValidationEngine(self.rules()).validate_all_detailed(
+            ValidationContext(stdin_text="feat: added x")
+        )
+        by_check = {o.check: o for o in outcomes}
+        assert by_check["message"].status == "pass"
+        assert by_check["subject_imperative"].status == "warn"
+        # The finding keeps its full detail; only the verdict changes.
+        assert by_check["subject_imperative"].error == "Not imperative"
+        assert by_check["subject_imperative"].suggest == "Use the imperative"
+        assert overall_status(o.status for o in outcomes) == "pass"
+        assert count_warnings(o.status for o in outcomes) == 1
+
+    def test_a_real_failure_still_fails_alongside_a_warning(self):
+        outcomes = ValidationEngine(self.rules()).validate_all_detailed(
+            ValidationContext(stdin_text="added x")
+        )
+        assert {o.check: o.status for o in outcomes} == {
+            "message": "fail",
+            "subject_imperative": "warn",
+        }
+        assert overall_status(o.status for o in outcomes) == "fail"
+
+    def test_text_mode_passes_and_names_the_warning_on_stderr(self, capsys):
+        result = ValidationEngine(self.rules()).validate_all(
+            ValidationContext(stdin_text="feat: added x", no_banner=True)
+        )
+        out, err = capsys.readouterr()
+        assert result == ValidationResult.PASS
+        assert "subject-imperative check warning ==> feat: added x" in out
+        assert "does not fail the run" in out
+        assert "Commit rejected" not in out
+        assert "⚠ warnings (not enforced): subject-imperative" in err
+
+    def test_text_mode_still_fails_on_an_enforced_rule(self, capsys):
+        result = ValidationEngine(self.rules()).validate_all(
+            ValidationContext(stdin_text="added x", no_banner=True)
+        )
+        out, _ = capsys.readouterr()
+        assert result == ValidationResult.FAIL
+        assert "message check failed ==> added x" in out
+        assert "subject-imperative check warning ==> added x" in out
+
+    def test_overall_status_only_counts_failures(self):
+        assert overall_status(["warn", "pass"]) == "pass"
+        assert overall_status(["warn", "skip"]) == "pass"
+        assert overall_status(["warn", "fail"]) == "fail"
+        assert overall_status(["skip", "skip"]) == "skip"
+        assert count_warnings(["warn", "warn", "fail"]) == 2

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1331,3 +1331,57 @@ class TestFilesFlag:
         assert main() == 1
         out, _ = capfd.readouterr()
         assert "big.bin" in out
+
+
+class TestWarnLevel:
+    """``warn = [...]`` in the config reports a rule without failing the run."""
+
+    def _config(self, tmp_path):
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text(
+            'warn = ["subject_imperative"]\n\n[commit]\nsubject_imperative = true\n'
+        )
+        return str(cfg)
+
+    def test_json_reports_the_warning_and_exits_zero(
+        self, mocker, capsys, monkeypatch, tmp_path, pinned_author
+    ):
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: added x\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            [CMD, "-m", "--format", "json", "--config", self._config(tmp_path)],
+        )
+        rc = main()
+        data = json.loads(capsys.readouterr().out)
+        assert rc == 0
+        assert data["status"] == "pass"
+        assert data["warnings"] == 1
+        by_check = {c["check"]: c for c in data["checks"]}
+        assert by_check["subject_imperative"]["status"] == "warn"
+        assert by_check["subject_imperative"]["error"]
+
+    def test_text_mode_exits_zero_with_a_notice(
+        self, mocker, capsys, monkeypatch, tmp_path, pinned_author
+    ):
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: added x\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", self._config(tmp_path)])
+        rc = main()
+        out, err = capsys.readouterr()
+        assert rc == 0
+        assert "subject-imperative check warning ==> feat: added x" in out
+        assert "Commit rejected" not in out
+        assert "⚠ warnings (not enforced): subject-imperative" in err
+
+    def test_unknown_warn_name_is_a_config_error(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text('warn = ["branchh"]\n')
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", str(cfg)])
+        rc = main()
+        assert rc == 1
+        assert "unknown rule 'branchh'" in capsys.readouterr().err

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -656,3 +656,44 @@ class TestFilesRules:
         assert not [
             r for r in rules if r.check in ("file_size", "file_pattern", "path_length")
         ]
+
+
+class TestWarnSeverity:
+    """The top-level ``warn`` list demotes named rules to warnings."""
+
+    def test_rules_are_errors_by_default(self):
+        rules = RuleBuilder({"commit": {}, "branch": {}}).build_all_rules()
+        assert rules and all(r.severity == "error" for r in rules)
+
+    def test_named_check_becomes_a_warning(self):
+        rules = RuleBuilder({"warn": ["branch"], "branch": {}}).build_all_rules()
+        by_check = {r.check: r for r in rules}
+        assert by_check["branch"].severity == "warn"
+        assert by_check["message"].severity == "error"
+
+    def test_rule_id_is_accepted_in_any_case(self):
+        rules = RuleBuilder(
+            {"warn": ["cc201", "CC003"], "commit": {"subject_imperative": True}}
+        ).build_all_rules()
+        by_check = {r.check: r for r in rules}
+        assert by_check["branch"].severity == "warn"
+        assert by_check["subject_imperative"].severity == "warn"
+
+    def test_single_name_may_be_given_as_a_string(self):
+        rules = RuleBuilder({"warn": "branch"}).build_all_rules()
+        assert {r.check: r.severity for r in rules}["branch"] == "warn"
+
+    def test_unknown_name_is_refused_with_the_known_rules(self):
+        with pytest.raises(ValueError, match="unknown rule 'branchh'.*\\bbranch\\b"):
+            RuleBuilder({"warn": ["branchh"]})
+
+    def test_non_list_is_refused(self):
+        with pytest.raises(ValueError, match="must be a list"):
+            RuleBuilder({"warn": {"branch": True}})
+
+    def test_to_dict_carries_severity(self):
+        assert ValidationRule(check="branch").to_dict()["severity"] == "error"
+        assert (
+            ValidationRule(check="branch", severity="warn").to_dict()["severity"]
+            == "warn"
+        )

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -671,6 +671,14 @@ class TestWarnSeverity:
         assert by_check["branch"].severity == "warn"
         assert by_check["message"].severity == "error"
 
+    def test_check_name_is_accepted_in_any_case(self):
+        rules = RuleBuilder(
+            {"warn": ["BRANCH", " Subject_Max_Length "]}
+        ).build_all_rules()
+        by_check = {r.check: r.severity for r in rules}
+        assert by_check["branch"] == "warn"
+        assert by_check["subject_max_length"] == "warn"
+
     def test_rule_id_is_accepted_in_any_case(self):
         rules = RuleBuilder(
             {"warn": ["cc201", "CC003"], "commit": {"subject_imperative": True}}

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -679,6 +679,11 @@ class TestWarnSeverity:
         assert by_check["branch"].severity == "warn"
         assert by_check["subject_imperative"].severity == "warn"
 
+    def test_none_means_no_warnings(self):
+        # A config assembled in Python may carry an explicit None; TOML cannot.
+        rules = RuleBuilder({"warn": None}).build_all_rules()
+        assert rules and all(r.severity == "error" for r in rules)
+
     def test_single_name_may_be_given_as_a_string(self):
         rules = RuleBuilder({"warn": "branch"}).build_all_rules()
         assert {r.check: r.severity for r in rules}["branch"] == "warn"

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -663,7 +663,8 @@ class TestWarnSeverity:
 
     def test_rules_are_errors_by_default(self):
         rules = RuleBuilder({"commit": {}, "branch": {}}).build_all_rules()
-        assert rules and all(r.severity == "error" for r in rules)
+        assert rules
+        assert all(r.severity == "error" for r in rules)
 
     def test_named_check_becomes_a_warning(self):
         rules = RuleBuilder({"warn": ["branch"], "branch": {}}).build_all_rules()
@@ -673,7 +674,10 @@ class TestWarnSeverity:
 
     def test_check_name_is_accepted_in_any_case(self):
         rules = RuleBuilder(
-            {"warn": ["BRANCH", " Subject_Max_Length "]}
+            {
+                "warn": ["BRANCH", " Subject_Max_Length "],
+                "commit": {"subject_max_length": 72},
+            }
         ).build_all_rules()
         by_check = {r.check: r.severity for r in rules}
         assert by_check["branch"] == "warn"
@@ -690,7 +694,8 @@ class TestWarnSeverity:
     def test_none_means_no_warnings(self):
         # A config assembled in Python may carry an explicit None; TOML cannot.
         rules = RuleBuilder({"warn": None}).build_all_rules()
-        assert rules and all(r.severity == "error" for r in rules)
+        assert rules
+        assert all(r.severity == "error" for r in rules)
 
     def test_single_name_may_be_given_as_a_string(self):
         rules = RuleBuilder({"warn": "branch"}).build_all_rules()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1446,3 +1446,39 @@ class TestIdentityLookups:
         assert get_commit_author_identity("abc") == ("Jane Doe", "jane@example.com")
         assert "--pretty=format:%an%x1f%ae" in cmd.call_args[0][0]
         assert cmd.call_args[0][0][-1] == "abc"
+
+
+class TestPrintFailureWarnSeverity:
+    def check(self):
+        return {
+            "check": "branch",
+            "rule_id": "CC201",
+            "error": "Bad branch",
+            "suggest": "Rename it",
+            "docs_url": "https://commit-check.com/rules/#cc201",
+            "severity": "warn",
+        }
+
+    def test_warning_block_has_no_banner_and_says_so(self, capfd, monkeypatch):
+        from commit_check.util import _print_failure, print_error_header
+
+        monkeypatch.setattr(print_error_header, "has_been_called", False)
+        monkeypatch.setenv("FORCE_HYPERLINK", "0")
+        _print_failure(self.check(), "Feature/x")
+        out = capfd.readouterr().out
+        assert "Commit rejected" not in out
+        assert "branch check warning ==> " in out
+        assert "check failed" not in out
+        assert "Suggest: " in out
+        assert "Docs: https://commit-check.com/rules/#cc201" in out
+        assert (
+            "This rule is set to warn in the config; it does not fail the run." in out
+        )
+        # And the banner is still owed to the next real failure.
+        assert print_error_header.has_been_called is False
+
+    def test_compact_warning_is_labelled_warn(self, capfd):
+        from commit_check.util import _print_failure
+
+        _print_failure(self.check(), "Feature/x", compact=True)
+        assert capfd.readouterr().out == "[WARN] CC201 branch: Feature/x\n"


### PR DESCRIPTION
## What

A rule has been on or off. Turning one on for a team that is still converging meant red checks on every push; turning it off meant losing the information. This adds a third setting:

```toml
warn = ["branch", "CC003"]

[commit]
subject_imperative = true

[branch]
conventional_branch = true
```

A rule listed under `warn` runs, its finding prints in full, and it never fails the run. Entries name a check (`branch`) or its rule ID (`CC003`, any case). A name that matches nothing is a configuration error with the list of known rules, so a typo cannot leave a rule silently enforced.

## Behaviour

**Text output** (real output on this branch):

```
CC201 branch check warning ==> jsmith/fix-x
The branch should follow Conventional Branch. See https://conventionalbranch.org
Suggest: Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass
Docs: https://commit-check.com/rules/#cc201
This rule is set to warn in the config; it does not fail the run.

⚠ warnings (not enforced): branch        ← stderr, like the skip notice
$ echo $?
0
```

No rejection banner for a warning; the banner is still owed to the next enforced failure. `--compact` prints `[WARN] CC201 branch: jsmith/fix-x`.

**JSON and Python API**: the check's `status` is `warn`, the top-level `status` stays `pass` unless an enforced rule failed, and a top-level `warnings` count is added. `overall_status` already counted only `fail`, so consumers testing for that value (the App, the Action, the MCP server) are unaffected; they can start rendering `warn` when they choose.

**Exit code** counts only enforced rules.

## How

- `ValidationRule.severity` (`"error"` default, `"warn"`), set by `RuleBuilder` from the top-level list after all rules are built; carried in `to_dict()` so the printer sees it.
- `ValidationEngine.validate_all` tracks failures per rule severity and prints the stderr notice; `validate_all_detailed` maps a failed warn-rule to `status="warn"`.
- `util._print_failure` / `print_error_message` gain the warn variant; new `engine.count_warnings`.
- README: `warn` in the config example, a "Report a rule without enforcing it" section, and `warnings` / `warn` in the JSON schema and samples.

Not included, on purpose: numeric levels, "fail when warnings exceed N", per-author levels.

## Tests

19 new tests across rule builder (name/ID resolution, refusal of unknown names and non-lists), engine (warn vs fail outcomes, text-mode exit and notices, `overall_status` / `count_warnings`), util (warn block without banner, compact label), main (`--format json` and text mode end to end through `--config`, unknown-name error), and the API (`warnings` count). Full suite: 783 passed; the one failure, `test_load_config_file_permission_error`, is pre-existing and root-only. `pre-commit run --all-files` clean.

README pins checked: all three `rev: v2.16.0` match the PyPI release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable warning-level checks using the `warn` setting.
  - Warning-level findings are reported without failing validation.
  - Text output now labels warnings clearly and explains that they are not enforced.
  - JSON and API results include warning counts and per-check `warn` statuses.
  - Supports warning configuration by check name or rule ID.

- **Bug Fixes**
  - Invalid or unknown warning configuration entries now produce clear configuration errors.

- **Documentation**
  - Updated configuration, CLI, JSON, and API documentation with warning behavior and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->