### PR TITLE
docs: update commit-check version to v2.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ commit-check --message --branch
 ```yaml
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: check-message
       - id: check-branch
@@ -218,7 +218,7 @@ commit-check --message
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: check-message
         args:
@@ -248,7 +248,7 @@ commit-check --no-force-push
 # In pre-commit hooks (.pre-commit-config.yaml)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: check-no-force-push
         stages: [pre-push]
@@ -280,7 +280,7 @@ commit-check --tag --tag-regex '^v\d+\.\d+\.\d+$'
 # a push carries, from the pre-push ref metadata on stdin
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: check-tag
         stages: [pre-push]
@@ -320,7 +320,7 @@ commit-check --files --rev abc1234
 # (a tag on already-pushed history adds nothing, so it is skipped)
 repos:
   - repo: https://github.com/commit-check/commit-check
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: check-files
         stages: [pre-push]


### PR DESCRIPTION
## What

Moves every `rev:` pin in the README (five pre-commit snippets) from `v2.16.0` to `v2.17.0`, ahead of the tag, as AGENTS.md prescribes for a release pull request: the snippets a new user copies should install the version the README describes.

## Release checklist for v2.17.0

This is the pull request that prepares an unpublished release, so the pins are written ahead of the tag on purpose. To publish after merging:

1. In the release draft, change the tag and title from `v2.16.1` to `v2.17.0`: two features since 2.16.0 (#564, #565) make this a minor release, not a patch.
2. Add one line to the notes under a "Changed" or "Fixed" heading: CC002 `subject_capitalized` now reads a plain subject from its first word. `Add feature` and `Update` pass where they failed before; `add Feature` fails where it passed before.
3. Publish the release; the publish workflow pushes to PyPI.

`.pre-commit-config.yaml` is left alone, per AGENTS.md: it resolves against real tags in CI and is bumped after the release exists.

## Checks

- `pre-commit run --all-files` clean.
- Full suite: 785 passed; the one failure, `test_load_config_file_permission_error`, is pre-existing and root-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all pre-commit configuration examples to reference release `v2.17.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->