### PR TITLE
chore: link spec names in errors and shorten long rule suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,7 +662,7 @@ Commit rejected.
 
 CC201 branch check failed ==> test-branch
 The branch should follow Conventional Branch. See https://conventionalbranch.org
-Suggest: Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass
+Suggest: Use <type>/<description> with an allowed type, or add the branch to allow_branch_names in config
 Docs: https://commit-check.com/rules/#cc201
 ```
 

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -61,6 +61,18 @@ class ValidationRule:
         entry = RULES_BY_CHECK.get(self.check)
         return entry.docs_url if entry else None
 
+    @property
+    def spec_name(self) -> str | None:
+        """Name of the specification the rule enforces, from the catalog."""
+        entry = RULES_BY_CHECK.get(self.check)
+        return entry.spec_name if entry else None
+
+    @property
+    def spec_url(self) -> str | None:
+        """Address of the specification the rule enforces, from the catalog."""
+        entry = RULES_BY_CHECK.get(self.check)
+        return entry.spec_url if entry else None
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for backward compatibility."""
         result: dict[str, Any] = {
@@ -74,6 +86,9 @@ class ValidationRule:
             result["rule_id"] = self.rule_id
         if self.docs_url:
             result["docs_url"] = self.docs_url
+        if self.spec_name and self.spec_url:
+            result["spec_name"] = self.spec_name
+            result["spec_url"] = self.spec_url
         if self.value is not None:
             result["value"] = self.value
         if self.allowed:

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -48,6 +48,12 @@ class RuleCatalogEntry:
     error: str | None = None
     suggest: str | None = None
     rule_id: str | None = None
+    # The specification the rule enforces. ``error`` must mention ``spec_name``
+    # and end with ``. See {spec_url}``: terminals with hyperlink support link
+    # the name and drop the trailing address, everything else prints ``error``
+    # verbatim so the URL still reaches CI logs and pipes.
+    spec_name: str | None = None
+    spec_url: str | None = None
 
     @property
     def name(self) -> str:
@@ -70,6 +76,8 @@ COMMIT_RULES = [
         regex=None,  # Built dynamically from config
         error="The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
         suggest="Use <type>(<scope>): <description> with allowed types",
+        spec_name="Conventional Commits",
+        spec_url="https://www.conventionalcommits.org",
     ),
     RuleCatalogEntry(
         rule_id="CC002",
@@ -197,14 +205,14 @@ FILES_RULES = [
         check="file_size",
         regex=None,
         error="File exceeds the maximum size of {max_size}",
-        suggest="Keep files under {max_size}, or store large assets outside git (e.g. Git LFS); raise max_size in the [files] config section if the limit is wrong",
+        suggest="Keep files under {max_size}, use Git LFS for large assets, or raise max_size in the [files] config",
     ),
     RuleCatalogEntry(
         rule_id="CC303",
         check="file_pattern",
         regex=None,
         error="File path matches a prohibited pattern",
-        suggest="Remove the file from the commit (secrets already committed need their credentials rotated), or adjust prohibited_patterns in the [files] config section",
+        suggest="Remove the file from the commit (rotate any committed secrets), or adjust prohibited_patterns in the [files] config",
     ),
     RuleCatalogEntry(
         rule_id="CC304",
@@ -222,7 +230,9 @@ BRANCH_RULES = [
         check="branch",
         regex=None,  # Built dynamically from config
         error="The branch should follow Conventional Branch. See https://conventionalbranch.org",
-        suggest="Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass",
+        suggest="Use <type>/<description> with an allowed type, or add the branch to allow_branch_names in config",
+        spec_name="Conventional Branch",
+        spec_url="https://conventionalbranch.org",
     ),
     RuleCatalogEntry(
         rule_id="CC202",

--- a/commit_check/util.py
+++ b/commit_check/util.py
@@ -45,6 +45,8 @@ def _print_failure(
         rule_id=rule_id,
         docs_url=docs_url,
         warn=warn,
+        spec_name=check.get("spec_name", "") or "",
+        spec_url=check.get("spec_url", "") or "",
     )
     if check.get("suggest"):
         print_suggestion(check["suggest"])
@@ -652,6 +654,8 @@ def print_error_message(
     rule_id: str = "",
     docs_url: str = "",
     warn: bool = False,
+    spec_name: str = "",
+    spec_url: str = "",
 ) -> None:
     """Print error message.
 
@@ -663,6 +667,10 @@ def print_error_message(
         terminal supports it
     :param warn: the rule is reported, not enforced: say ``warning`` rather
         than ``failed``, and colour the value as a caution, not an error
+    :param spec_name: name of the specification mentioned in ``error``, linked
+        from the name when the terminal supports it
+    :param spec_url: address of that specification; ``error`` carries it as a
+        trailing ``. See {spec_url}``, dropped once the name is a link
 
     :returns: Give error messages to user
     """
@@ -676,6 +684,12 @@ def print_error_message(
         f"{prefix}{YELLOW}{name}{RESET_COLOR} check {verdict} ==> {colour}{reason}{RESET_COLOR}"
     )
     if error:
+        # Same trade-off as the Docs: line above — once the spec name is a
+        # link, spelling out its address only adds noise; without hyperlink
+        # support the untouched text is how the reader gets the URL at all.
+        if spec_name and spec_url and supports_hyperlinks():
+            error = error.replace(f". See {spec_url}", "")
+            error = error.replace(spec_name, hyperlink(spec_name, spec_url))
         print(error)
 
 

--- a/tests/rules_catalog_test.py
+++ b/tests/rules_catalog_test.py
@@ -88,6 +88,21 @@ class TestRuleIds:
         """The display name is the kebab-case form of the config key."""
         assert RuleCatalogEntry(check="subject_imperative").name == "subject-imperative"
 
+    @pytest.mark.benchmark
+    def test_spec_fields_match_the_error_text(self):
+        """The error text must carry the spec exactly as the fields say.
+
+        Hyperlink rendering rewrites the error by string replacement: it strips
+        the trailing ``. See {spec_url}`` and wraps ``spec_name`` in a link. If
+        either drifts out of the text, the rewrite silently does nothing.
+        """
+        for entry in ALL_ENTRIES:
+            if entry.spec_url or entry.spec_name:
+                assert entry.spec_name and entry.spec_url, entry.check
+                assert entry.error, entry.check
+                assert entry.spec_name in entry.error, entry.check
+                assert entry.error.endswith(f". See {entry.spec_url}"), entry.check
+
 
 class TestRuleIdPropagation:
     """Built rules carry their catalog identity through to output."""

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -710,6 +710,69 @@ class TestUtil:
             assert "CC005" in stdout
 
         @pytest.mark.benchmark
+        def test_spec_name_is_linked_when_supported(self, capfd, mocker):
+            """The spec name becomes the link; the spelled-out URL goes."""
+            mocker.patch("commit_check.util.supports_hyperlinks", return_value=True)
+            print_error_message(
+                "branch",
+                "The branch should follow Conventional Branch. See https://conventionalbranch.org",
+                "Feature/x",
+                rule_id="CC201",
+                docs_url="https://commit-check.com/rules/#cc201",
+                spec_name="Conventional Branch",
+                spec_url="https://conventionalbranch.org",
+            )
+            stdout, _ = capfd.readouterr()
+            assert (
+                "\033]8;;https://conventionalbranch.org\033\\"
+                "Conventional Branch\033]8;;\033\\" in stdout
+            )
+            assert "See https://conventionalbranch.org" not in stdout
+
+        @pytest.mark.benchmark
+        def test_spec_url_kept_verbatim_when_unsupported(self, capfd, mocker):
+            """A CI log still needs the address written out."""
+            mocker.patch("commit_check.util.supports_hyperlinks", return_value=False)
+            print_error_message(
+                "branch",
+                "The branch should follow Conventional Branch. See https://conventionalbranch.org",
+                "Feature/x",
+                rule_id="CC201",
+                docs_url="https://commit-check.com/rules/#cc201",
+                spec_name="Conventional Branch",
+                spec_url="https://conventionalbranch.org",
+            )
+            stdout, _ = capfd.readouterr()
+            assert "\033]8;;" not in stdout
+            assert (
+                "The branch should follow Conventional Branch."
+                " See https://conventionalbranch.org" in stdout
+            )
+
+        @pytest.mark.benchmark
+        def test_spec_fields_flow_through_print_failure(self, capfd, mocker):
+            mocker.patch("commit_check.util.supports_hyperlinks", return_value=True)
+            _print_failure(
+                {
+                    "check": "message",
+                    "error": "The commit message should follow Conventional Commits. See https://www.conventionalcommits.org",
+                    "suggest": "Use <type>(<scope>): <description>",
+                    "rule_id": "CC001",
+                    "docs_url": "https://commit-check.com/rules/#cc001",
+                    "spec_name": "Conventional Commits",
+                    "spec_url": "https://www.conventionalcommits.org",
+                },
+                "added stuff",
+                no_banner=True,
+            )
+            stdout, _ = capfd.readouterr()
+            assert (
+                "\033]8;;https://www.conventionalcommits.org\033\\"
+                "Conventional Commits\033]8;;\033\\" in stdout
+            )
+            assert "See https://www.conventionalcommits.org" not in stdout
+
+        @pytest.mark.benchmark
         def test_docs_line_kept_without_hyperlinks(self, capfd, mocker):
             """A CI log is where the printed URL is the only way to reach it."""
             mocker.patch("commit_check.util.supports_hyperlinks", return_value=False)


### PR DESCRIPTION
## What

Two output-polish changes to failure messages:

**1. Spec URLs render as terminal hyperlinks**

In terminals with OSC 8 support, the spec name in the CC001/CC201 error text ("Conventional Commits" / "Conventional Branch") is now a clickable link and the spelled-out `See https://...` tail is dropped — the same treatment the rule ID already gets for its docs URL, and the same trade-off as the existing `Docs:` line suppression.

Everywhere without hyperlink support (CI logs, pipes, plain terminals) the output stays **byte-identical** to before, so the address still reaches readers who cannot click. JSON output is unchanged.

With hyperlinks:
```
CC201 branch check failed ==> Feature/x
The branch should follow Conventional Branch        <- clickable, links to the spec
Suggest: Use <type>/<description> with an allowed type, or add the branch to allow_branch_names in config
```

Fallback (unchanged):
```
CC201 branch check failed ==> Feature/x
The branch should follow Conventional Branch. See https://conventionalbranch.org
Suggest: Use <type>/<description> with an allowed type, or add the branch to allow_branch_names in config
Docs: https://commit-check.com/rules/#cc201
```

**2. Shorter suggestions for CC201, CC302, CC303**

The longest suggestions are trimmed to one action plus one config escape hatch, in line with CC001's length:

| Rule | Before | After |
|------|--------|-------|
| CC201 | `Use <type>/<description> with allowed types or add branch name to allow_branch_names in config, or use ignore_authors in config branch section to bypass` | `Use <type>/<description> with an allowed type, or add the branch to allow_branch_names in config` |
| CC302 | `Keep files under {max_size}, or store large assets outside git (e.g. Git LFS); raise max_size in the [files] config section if the limit is wrong` | `Keep files under {max_size}, use Git LFS for large assets, or raise max_size in the [files] config` |
| CC303 | `Remove the file from the commit (secrets already committed need their credentials rotated), or adjust prohibited_patterns in the [files] config section` | `Remove the file from the commit (rotate any committed secrets), or adjust prohibited_patterns in the [files] config` |

## How

- `RuleCatalogEntry` gains optional `spec_name`/`spec_url` fields; `ValidationRule` derives them from the catalog like `rule_id`/`docs_url`, so no rule construction site changes.
- The catalog `error` string keeps its `. See {spec_url}` tail; `print_error_message` strips it and wraps the name in a link only when `supports_hyperlinks()` is true. A new catalog test pins the error text to the spec fields so the string rewrite cannot silently drift into a no-op.

## Testing

- 790 tests pass, including 3 new rendering cases and 1 new catalog consistency assertion.
- Verified end-to-end with the real CLI under `FORCE_HYPERLINK=1` (name linked, no bare URL, no Docs line) and `FORCE_HYPERLINK=0` (byte-identical to current output), plus `--format json` (error field unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Validation errors now include specification names linked to their documentation when supported by the terminal.
  - Specification URLs remain visible in environments without hyperlink support.
  - Commit and branch checks now identify the specifications they enforce.

- **Improvements**
  - Updated wording for several branch and file-rule suggestions.
  - Refined the branch-check failure example to avoid suggesting bypassing checks.

- **Tests**
  - Added coverage for specification metadata, hyperlink rendering, and fallback URL display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->