### PR TITLE
fix: run the checks under --dry-run, exit 2 and name the file on config errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [Organization-Level Configuration (inherit_from)](#organization-level-configuration-inherit_from)
   - [Use CLI Arguments or Environment Variables](#use-cli-arguments-or-environment-variables)
   - [Check Push Safety](#check-push-safety)
+  - [Exit Codes and Dry Run](#exit-codes-and-dry-run)
 - [AI-Native Usage](#ai-native-usage)
   - [Machine-Readable JSON Output (--format json)](#machine-readable-json-output---format-json)
   - [Quieter Human-Readable Output](#quieter-human-readable-output)
@@ -331,6 +332,43 @@ adds nothing to police. Content scanning (entropy, token detection) is
 deliberately out of scope: pair these checks with a scanner like gitleaks
 if you need it.
 
+### Exit Codes and Dry Run
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | Every enforced check passed, or every check was skipped. |
+| `1` | A check failed. This is a verdict on the commit. |
+| `2` | The run could not start: bad usage, a `--rev` that does not resolve, or a config file that is missing, is not valid TOML, or names an unknown rule. Nothing was validated. |
+
+A configuration error names the file, so a broken `.github/cchk.toml` is
+reported as:
+
+```text
+Error: .github/cchk.toml: Expected ']' at the end of a table declaration (at line 1, column 8)
+```
+
+Scripts that treat any non-zero exit as a rejected commit keep working. Scripts
+that want to tell a broken policy from a broken commit can check for `2`, which
+is also the code `argparse` uses for a bad command line.
+
+`--dry-run` runs every requested check and prints the findings exactly as a
+normal run does, then exits `0` even when a check failed, with one line on
+stderr saying so:
+
+```bash
+echo "wip bad commit" | commit-check -m --dry-run --compact
+```
+
+```text
+[FAIL] CC001 message: wip bad commit
+⊘ dry run: a check failed, but --dry-run forces exit code 0
+```
+
+Use it to preview a rule set in CI before enforcing it. In `--format json` the
+`status` still says `fail`; only the exit code is softened. A configuration
+error is not softened: nothing ran, so there is nothing to preview, and a green
+exit would hide the broken file.
+
 ## AI-Native Usage
 
 Commit Check is designed to be consumed by AI agents, LLM toolchains, and
@@ -339,7 +377,8 @@ automation scripts — not just by humans reading terminal output.
 ### Machine-Readable JSON Output (`--format json`)
 
 Pass `--format json` to any CLI invocation to receive structured JSON instead
-of human-readable ASCII art.  The exit code is unchanged (`0` = pass, `1` = fail),
+of human-readable ASCII art.  The exit code is unchanged (`0` = pass, `1` = fail,
+`2` = configuration error; see [Exit Codes and Dry Run](#exit-codes-and-dry-run)),
 so existing CI scripts continue to work:
 
 ```bash

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -219,15 +219,15 @@ def _load_toml_file(path: Path, shown_as: str | None = None) -> dict[str, Any]:
 
 
 def find_config_path(path_hint: str = "") -> Path | None:
-    """The config file a run reads, as the user would name it, or ``None``.
+    """The config file a run reads, or ``None`` when there is none.
 
-    With ``path_hint`` that is the hint itself, if it exists. Without one it
-    is the first of :data:`DEFAULT_CONFIG_PATHS` that exists. Kept separate
-    from :func:`load_config` so an error found later, in a setting the merged
-    dict no longer attributes to a file, can still name the file.
+    With ``path_hint`` that is the hint, canonicalised, if it exists. Without
+    one it is the first of :data:`DEFAULT_CONFIG_PATHS` that exists. Kept
+    separate from :func:`load_config` so an error found later, in a setting
+    the merged dict no longer attributes to a file, can still name the file.
     """
     if path_hint:
-        p = Path(path_hint)
+        p = Path(path_hint).resolve()
         return p if p.exists() else None
     for candidate in DEFAULT_CONFIG_PATHS:
         if candidate.exists():

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -16,6 +16,17 @@ except ImportError:
 
     toml_load = tomli.load
 
+
+class ConfigError(ValueError):
+    """A configuration that cannot be used: a TOML file that does not parse,
+    or a setting that names something that does not exist.
+
+    The message names the offending file where there is one. The CLI reports
+    these as exit code 2, apart from a rejected commit (exit code 1), so a
+    wrapper can tell a broken policy from a broken commit.
+    """
+
+
 DEFAULT_CONFIG_PATHS = [
     Path("cchk.toml"),
     Path("commit-check.toml"),
@@ -189,27 +200,44 @@ def _resolve_inherit_from(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def _load_toml_file(path: Path, shown_as: str | None = None) -> dict[str, Any]:
+    """Parse one TOML file, naming it in the error when it does not parse.
+
+    ``TOMLDecodeError`` carries a line and column but no file name, and the
+    CLI can be reading any of four default locations, so without the name
+    the user is left to guess which file is broken.
+
+    :param path: File to read.
+    :param shown_as: The path as the user wrote it, for the error message.
+    :raises ConfigError: If the file is not valid TOML.
+    """
+    with open(path, "rb") as f:
+        try:
+            return toml_load(f)
+        except ValueError as e:  # TOMLDecodeError is a ValueError
+            raise ConfigError(f"{shown_as or path}: {e}") from e
+
+
 def load_config(path_hint: str = "") -> dict[str, Any]:
     """Load and validate config from TOML file.
 
     Supports ``inherit_from`` at the top level to merge an organization-level
     configuration from a local file path, a ``github:`` shorthand, or an HTTPS
     URL before applying local overrides.
+
+    :raises FileNotFoundError: If ``path_hint`` names a file that does not exist.
+    :raises ConfigError: If the file is not valid TOML; the message names it.
     """
     if path_hint:
         p = Path(path_hint).resolve()
         if not p.exists():
             raise FileNotFoundError(f"Specified config file not found: {path_hint}")
-        with open(p, "rb") as f:
-            config = toml_load(f)
-        return _resolve_inherit_from(config)
+        return _resolve_inherit_from(_load_toml_file(p, shown_as=path_hint))
 
     # Check default config paths only when no specific path is provided
     for candidate in DEFAULT_CONFIG_PATHS:
         if candidate.exists():
-            with open(candidate, "rb") as f:
-                config = toml_load(f)
-            return _resolve_inherit_from(config)
+            return _resolve_inherit_from(_load_toml_file(candidate))
 
     # Return empty config if no default config files found
     return {}

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -218,6 +218,23 @@ def _load_toml_file(path: Path, shown_as: str | None = None) -> dict[str, Any]:
             raise ConfigError(f"{shown_as or path}: {e}") from e
 
 
+def find_config_path(path_hint: str = "") -> Path | None:
+    """The config file a run reads, as the user would name it, or ``None``.
+
+    With ``path_hint`` that is the hint itself, if it exists. Without one it
+    is the first of :data:`DEFAULT_CONFIG_PATHS` that exists. Kept separate
+    from :func:`load_config` so an error found later, in a setting the merged
+    dict no longer attributes to a file, can still name the file.
+    """
+    if path_hint:
+        p = Path(path_hint)
+        return p if p.exists() else None
+    for candidate in DEFAULT_CONFIG_PATHS:
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def load_config(path_hint: str = "") -> dict[str, Any]:
     """Load and validate config from TOML file.
 
@@ -228,16 +245,10 @@ def load_config(path_hint: str = "") -> dict[str, Any]:
     :raises FileNotFoundError: If ``path_hint`` names a file that does not exist.
     :raises ConfigError: If the file is not valid TOML; the message names it.
     """
-    if path_hint:
-        p = Path(path_hint).resolve()
-        if not p.exists():
+    path = find_config_path(path_hint)
+    if path is None:
+        if path_hint:
             raise FileNotFoundError(f"Specified config file not found: {path_hint}")
-        return _resolve_inherit_from(_load_toml_file(p, shown_as=path_hint))
-
-    # Check default config paths only when no specific path is provided
-    for candidate in DEFAULT_CONFIG_PATHS:
-        if candidate.exists():
-            return _resolve_inherit_from(_load_toml_file(candidate))
-
-    # Return empty config if no default config files found
-    return {}
+        # No default config file: run on the built-in defaults.
+        return {}
+    return _resolve_inherit_from(_load_toml_file(path, shown_as=path_hint or None))

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -643,7 +643,9 @@ def main() -> int:
         except ConfigError as e:
             # The merged dict no longer says which file a setting came from,
             # and ``warn`` has no env or CLI form, so it was the TOML file.
-            source = find_config_path(args.config or "")
+            # An explicit --config is named as the user wrote it; otherwise
+            # say which of the default locations was found.
+            source = args.config or find_config_path()
             raise ConfigError(f"{source}: {e}" if source else str(e)) from e
 
         # Determine which checks to run

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -6,6 +6,7 @@ import os
 import sys
 import argparse
 
+from commit_check.config import ConfigError
 from commit_check.config_merger import ConfigMerger, parse_bool, parse_list, parse_int
 from commit_check.rule_builder import RuleBuilder
 from commit_check.engine import (
@@ -17,6 +18,13 @@ from commit_check.engine import (
     overall_status,
 )
 from . import __version__
+
+# Exit codes. ``1`` is a verdict on the commit; ``2`` means the run could not
+# be set up at all -- the same code argparse uses for a bad command line -- so
+# a wrapper can tell a rejected commit from a broken configuration.
+EXIT_PASS = 0
+EXIT_FAIL = 1
+EXIT_CONFIG_ERROR = 2
 
 
 class StdinReader:
@@ -117,6 +125,13 @@ def _get_parser() -> argparse.ArgumentParser:
         prog="commit-check",
         description="Check commit message, branch name, author name, email, and more.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "exit codes:\n"
+            "  0  every enforced check passed, or --dry-run was given\n"
+            "  1  a check failed\n"
+            "  2  the run could not start: bad usage, or a missing or "
+            "invalid config file"
+        ),
     )
 
     parser.add_argument(
@@ -207,7 +222,8 @@ def _get_parser() -> argparse.ArgumentParser:
     check_group.add_argument(
         "-d",
         "--dry-run",
-        help="perform a dry run without failing (always returns 0)",
+        help="run every check and print the findings, but exit 0 even when "
+        "one fails; a configuration error still exits 2",
         action="store_true",
         required=False,
     )
@@ -587,9 +603,6 @@ def main() -> int:
     parser = _get_parser()
     args = parser.parse_args()
 
-    if args.dry_run:
-        return 0
-
     stdin_reader = StdinReader()
 
     try:
@@ -613,7 +626,7 @@ def main() -> int:
                     "in this repository",
                     file=sys.stderr,
                 )
-                return 1
+                return EXIT_CONFIG_ERROR
 
         # Load and merge configuration from all sources: CLI > Env > TOML > Defaults
         config_data = ConfigMerger.from_all_sources(args, args.config)
@@ -680,17 +693,30 @@ def main() -> int:
         # Run validation – choose output mode based on --format
         output_format: str = getattr(args, "output_format", "text")
         if output_format == "json":
-            return _run_json_output(engine, context)
+            exit_code = _run_json_output(engine, context)
+        else:
+            result = engine.validate_all(context)
+            exit_code = EXIT_PASS if result == ValidationResult.PASS else EXIT_FAIL
 
-        result = engine.validate_all(context)
-        return 0 if result == ValidationResult.PASS else 1
+        if args.dry_run and exit_code == EXIT_FAIL:
+            # The checks ran and their findings are printed above; only the
+            # verdict is softened, so a team can preview a rule set in CI
+            # without being blocked by it. Say so, or the green exit reads
+            # as a pass.
+            print(
+                "⊘ dry run: a check failed, but --dry-run forces exit code 0",
+                file=sys.stderr,
+            )
+            return EXIT_PASS
+        return exit_code
 
-    except FileNotFoundError as e:
+    except (FileNotFoundError, ConfigError) as e:
+        # Nothing was validated, so this is not a verdict on the commit.
         print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return EXIT_CONFIG_ERROR
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
-        return 1
+        return EXIT_FAIL
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -6,7 +6,7 @@ import os
 import sys
 import argparse
 
-from commit_check.config import ConfigError
+from commit_check.config import ConfigError, find_config_path
 from commit_check.config_merger import ConfigMerger, parse_bool, parse_list, parse_int
 from commit_check.rule_builder import RuleBuilder
 from commit_check.engine import (
@@ -637,8 +637,14 @@ def main() -> int:
             config_data.setdefault("push", {})["allow_force_push"] = False
 
         # Build validation rules from config
-        rule_builder = RuleBuilder(config_data)
-        all_rules = rule_builder.build_all_rules()
+        try:
+            rule_builder = RuleBuilder(config_data)
+            all_rules = rule_builder.build_all_rules()
+        except ConfigError as e:
+            # The merged dict no longer says which file a setting came from,
+            # and ``warn`` has no env or CLI form, so it was the TOML file.
+            source = find_config_path(args.config or "")
+            raise ConfigError(f"{source}: {e}" if source else str(e)) from e
 
         # Determine which checks to run
         requested_checks = _get_requested_checks(args)

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -148,11 +148,13 @@ class RuleBuilder:
         left the rule enforcing would be discovered by whoever it blocked.
         """
         # The common config lists nothing, and the builder runs once per
-        # check; that path pays for nothing here.
-        if not names:
+        # check; that path pays for nothing here. Only an absent key, an
+        # empty list or an empty string mean "nothing": ``warn = false`` is
+        # a type error, not a way to switch warnings off.
+        if names is None or names == []:
             return frozenset()
         if isinstance(names, str):
-            names = [names]
+            names = [names] if names.strip() else []
         if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
             raise ConfigError(
                 'warn must be a list of rule names, e.g. warn = ["branch"]'

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -6,6 +6,7 @@ import sys
 from typing import Any
 from dataclasses import dataclass, replace
 from functools import lru_cache
+from commit_check.config import ConfigError
 from commit_check.rules_catalog import (
     COMMIT_RULES,
     BRANCH_RULES,
@@ -153,7 +154,7 @@ class RuleBuilder:
         if isinstance(names, str):
             names = [names]
         if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
-            raise ValueError(
+            raise ConfigError(
                 'warn must be a list of rule names, e.g. warn = ["branch"]'
             )
         resolved = set()
@@ -165,7 +166,7 @@ class RuleBuilder:
                 resolved.add(_CHECKS_BY_LOWER_ID[key])
             else:
                 known = ", ".join(sorted(RULES_BY_CHECK))
-                raise ValueError(
+                raise ConfigError(
                     f"warn names an unknown rule {name!r}. Known rules: {known}"
                 )
         return frozenset(resolved)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -309,7 +309,7 @@ missing closing bracket
             f.flush()
 
             try:
-                with pytest.raises(ConfigError, match="[Ee]xpected") as excinfo:
+                with pytest.raises(ConfigError, match=r"[Ee]xpected") as excinfo:
                     load_config(f.name)
                 # The parser's message has a line and column but no file
                 # name; the loader adds the path as the user gave it.

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -7,6 +7,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from commit_check.config import (
+    ConfigError,
     load_config,
     DEFAULT_CONFIG_PATHS,
     _deep_merge,
@@ -308,10 +309,12 @@ missing closing bracket
             f.flush()
 
             try:
-                with pytest.raises(
-                    Exception, match="[Ee]xpected"
-                ):  # Should raise a TOML parsing error
+                with pytest.raises(ConfigError, match="[Ee]xpected") as excinfo:
                     load_config(f.name)
+                # The parser's message has a line and column but no file
+                # name; the loader adds the path as the user gave it.
+                assert str(excinfo.value).startswith(f"{f.name}: ")
+                assert isinstance(excinfo.value.__cause__, ValueError)
             finally:
                 os.unlink(f.name)
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -246,6 +246,25 @@ class TestIntegration:
         )
         assert main() == 0
 
+    @pytest.mark.benchmark
+    def test_dry_run_still_reports_what_would_fail(
+        self,
+        repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """The checks run against the real commit; only the verdict is softened."""
+        _git("commit", "--allow-empty", "-m", "bad message", cwd=repo)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["commit-check", "--message", "--dry-run", "--compact"],
+        )
+        assert main() == 0
+        out, err = capsys.readouterr()
+        assert "[FAIL] CC001 message: bad message" in out
+        assert "--dry-run forces exit code 0" in err
+
     # ── json format ─────────────────────────────────────────────────────
 
     @pytest.mark.benchmark

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -166,7 +166,7 @@ class TestMain:
         assert main() == 0
 
     def test_dry_run_runs_the_checks_and_reports_the_failure(
-        self, mocker, capsys, monkeypatch
+        self, mocker, capsys, monkeypatch, pinned_author
     ):
         """--dry-run used to return before loading anything, so nothing was
         checked and nothing was printed. The findings must be there; only
@@ -188,7 +188,9 @@ class TestMain:
         assert main() == 0
         assert "dry run" not in capsys.readouterr().err
 
-    def test_dry_run_json_keeps_the_real_status(self, mocker, capsys, monkeypatch):
+    def test_dry_run_json_keeps_the_real_status(
+        self, mocker, capsys, monkeypatch, pinned_author
+    ):
         """The JSON is the truth; the exit code is the only thing forced."""
         mocker.patch("sys.stdin.isatty", return_value=False)
         mocker.patch("sys.stdin.read", return_value="invalid commit message\n")
@@ -1481,4 +1483,7 @@ class TestWarnLevel:
         monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", str(cfg)])
         rc = main()
         assert rc == 2
-        assert "unknown rule 'branchh'" in capsys.readouterr().err
+        err = capsys.readouterr().err
+        assert "unknown rule 'branchh'" in err
+        # The merged config no longer knows the file; main() must add it.
+        assert f"Error: {cfg}: warn names" in err

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -165,6 +165,54 @@ class TestMain:
         monkeypatch.setattr("sys.argv", [CMD, "-m", "--dry-run"])
         assert main() == 0
 
+    def test_dry_run_runs_the_checks_and_reports_the_failure(
+        self, mocker, capsys, monkeypatch
+    ):
+        """--dry-run used to return before loading anything, so nothing was
+        checked and nothing was printed. The findings must be there; only
+        the exit code is softened, and the softening must be announced."""
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="invalid commit message\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--dry-run"])
+        assert main() == 0
+        out, err = capsys.readouterr()
+        assert "CC001" in out + err
+        assert "--dry-run forces exit code 0" in err
+
+    def test_dry_run_is_silent_about_itself_when_everything_passes(
+        self, mocker, capsys, monkeypatch
+    ):
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--dry-run"])
+        assert main() == 0
+        assert "dry run" not in capsys.readouterr().err
+
+    def test_dry_run_json_keeps_the_real_status(self, mocker, capsys, monkeypatch):
+        """The JSON is the truth; the exit code is the only thing forced."""
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="invalid commit message\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--dry-run", "--format", "json"])
+        assert main() == 0
+        out, err = capsys.readouterr()
+        payload = json.loads(out)
+        assert payload["status"] == "fail"
+        assert payload["checks"][0]["status"] == "fail"
+        assert "--dry-run forces exit code 0" in err
+
+    def test_dry_run_does_not_hide_a_configuration_error(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        """A broken config means nothing ran, so there is nothing to preview;
+        forcing 0 here would be exactly the false green --dry-run had."""
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text("[commit\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--dry-run", "--config", str(cfg)])
+        assert main() == 2
+        assert str(cfg) in capsys.readouterr().err
+
 
 class TestStdinReader:
     """Test StdinReader edge cases."""
@@ -293,7 +341,7 @@ class TestRevOption:
         self, two_commit_repo, monkeypatch, capsys
     ):
         monkeypatch.setattr("sys.argv", [CMD, "--message", "--rev", "no-such-ref"])
-        assert main() == 1
+        assert main() == 2
         assert "does not resolve" in capsys.readouterr().err
 
     def test_rev_empty_string_is_rejected_not_ignored(
@@ -303,7 +351,7 @@ class TestRevOption:
         fall through to the engine where git's own failure leaks into the
         checked value with a green exit."""
         monkeypatch.setattr("sys.argv", [CMD, "--message", "--rev", ""])
-        assert main() == 1
+        assert main() == 2
         assert "does not resolve" in capsys.readouterr().err
 
     def test_rev_and_a_message_file_conflict(self, two_commit_repo, monkeypatch):
@@ -380,9 +428,9 @@ class TestMainFunctionEdgeCases:
             ],
         )
 
-        # This should fail with proper error message when config file doesn't exist
+        # A missing config file is a configuration error, not a verdict
         result = main()
-        assert result == 1
+        assert result == 2
 
     # Removed problematic tests that had configuration dependency issues
 
@@ -440,13 +488,44 @@ class TestMainFunctionEdgeCases:
         )
 
         result = main()
-        assert result == 1
+        assert result == 2
 
         captured = capsys.readouterr()
         assert (
             "Error: Specified config file not found: /nonexistent/config.toml"
             in captured.err
         )
+
+    @pytest.mark.benchmark
+    def test_invalid_toml_names_the_file_and_exits_2(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        """TOMLDecodeError has a line and column but no file name; the CLI
+        may be reading any of four default locations, so it must add it."""
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text("[commit\nsubject_max_length = 50\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", str(cfg)])
+        assert main() == 2
+        err = capsys.readouterr().err
+        assert err.startswith("Error: ")
+        assert str(cfg) in err
+        assert "line 1" in err
+
+    @pytest.mark.benchmark
+    def test_invalid_default_config_names_the_file_too(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        """Without --config the file was found by search; name which one."""
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".github").mkdir()
+        (tmp_path / ".github" / "commit-check.toml").write_text("= broken\n")
+        monkeypatch.setattr("sys.argv", [CMD, "-m"])
+        assert main() == 2
+        assert ".github/commit-check.toml: " in capsys.readouterr().err
 
 
 class TestCLIArgumentIntegration:
@@ -1401,5 +1480,5 @@ class TestWarnLevel:
         cfg.write_text('warn = ["branchh"]\n')
         monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", str(cfg)])
         rc = main()
-        assert rc == 1
+        assert rc == 2
         assert "unknown rule 'branchh'" in capsys.readouterr().err

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -701,6 +701,18 @@ class TestWarnSeverity:
         with pytest.raises(ValueError, match="must be a list"):
             RuleBuilder({"warn": {"branch": True}})
 
+    @pytest.mark.parametrize("value", [False, 0])
+    def test_a_falsey_non_list_is_refused_not_taken_as_empty(self, value):
+        """``warn = false`` reads like "switch warnings off" but is a type
+        error; accepting it would hide the mistake."""
+        with pytest.raises(ValueError, match="must be a list"):
+            RuleBuilder({"warn": value})
+
+    @pytest.mark.parametrize("value", [[], ""])
+    def test_an_empty_list_or_string_means_no_warnings(self, value):
+        rules = RuleBuilder({"warn": value}).build_all_rules()
+        assert all(r.severity == "error" for r in rules)
+
     def test_to_dict_carries_severity(self):
         assert ValidationRule(check="branch").to_dict()["severity"] == "error"
         assert (


### PR DESCRIPTION
## What

Three related fixes to how the CLI reports a run that did not, or should not, produce a verdict.

### `--dry-run` actually runs the checks

`main()` returned `0` right after parsing arguments, before loading the config or building a single rule. A "dry run" was therefore no run at all: nothing was checked, nothing was printed, and the green exit told the user their commit was fine.

Now every requested check runs and prints its findings exactly as a normal run does. Only the verdict is softened: a failing run exits `0` with one line on stderr saying so, so the green exit cannot be mistaken for a pass.

```text
$ echo "bad message" | commit-check -m --dry-run --compact
[FAIL] CC001 message: bad message
⊘ dry run: a check failed, but --dry-run forces exit code 0
$ echo $?
0
```

In `--format json` the payload is untouched (`status: "fail"`); only the exit code is forced. A configuration error is **not** softened under `--dry-run`: nothing ran, so there is nothing to preview, and a green exit would hide the broken file.

### Config errors name the file

`TOMLDecodeError` carries a line and column but no file name, and the loader may have found the file in any of four default locations:

| Before | After |
|---|---|
| `Error: Expected ']' at the end of a table declaration (at line 1, column 8)` | `Error: .github/cchk.toml: Expected ']' at the end of a table declaration (at line 1, column 8)` |

The loader raises a new `ConfigError(ValueError)` with the path as the user gave it. `RuleBuilder` raises the same class for a `warn` entry that names an unknown rule, so existing `pytest.raises(ValueError)` callers are unaffected.

### Exit 2 for configuration and usage errors

A missing or invalid config file, an unknown `warn` rule, or a `--rev` that does not resolve now exit `2`, the code argparse already uses for a bad command line. A rejected commit is still `1`, so a wrapper can tell a broken policy from a broken commit. The duplicate `except FileNotFoundError` / `except Exception` blocks that both returned `1` are collapsed into one `(FileNotFoundError, ConfigError)` handler returning `2`, with the generic handler still returning `1`.

Exit codes are documented in `--help` (epilog) and in a new README section "Exit Codes and Dry Run".

## Compatibility

- Scripts that treat any non-zero exit as failure keep working.
- commit-check-action ignores the return code and reads the JSON / `Error:` text; the App matches on the `Error:` prefix. Neither passes `--dry-run` to the CLI, so neither sees a behaviour change.
- `ValueError` from `RuleBuilder` is now `ConfigError`, a subclass, so existing handlers still catch it.

## Testing

- 834 tests pass (one pre-existing `chmod 000` test is skipped locally because the sandbox runs as root; it does not touch these paths).
- New tests: dry-run prints the findings and the notice, is silent when everything passes, keeps `status: "fail"` in JSON, and still exits `2` on a broken config; invalid TOML via `--config` and via a default path both name the file; `--rev` and unknown-`warn` exit codes updated.
- Coverage on `config.py` 100%, `main.py` and `rule_builder.py` 99% (the uncovered lines predate this change).
- Self-tested against a real git repo with the working tree vs the released 2.17.0 on PATH: broken default config, broken `--config`, missing `--config`, unknown `warn`, bad `--rev`, dry-run in text and JSON, dry-run on a passing commit.
- `pre-commit run --all-files` clean (ruff, mypy, codespell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6

---
_Generated by [Claude Code](https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct exit codes for successful checks, failed checks, and configuration or usage errors.
  * Added documented `--dry-run` behavior: checks run and findings are displayed, while the command exits successfully.
  * Improved configuration error messages by identifying the affected file and line.
  * Documented exit codes and dry-run behavior in the README and CLI help.

* **Bug Fixes**
  * Invalid configuration, missing files, and unresolved revisions now return the dedicated configuration-error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->