### PR TITLE
docs: configuration reference table, contributor docs cleanup, dedupe helpers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,16 +20,19 @@ Always reference these instructions first and fallback to search or bash command
 ```
 commit_check/
 ├── main.py              # CLI entry point, argument parsing
+├── api.py               # Public Python API (validate_message, validate_branch, ...)
 ├── config_merger.py     # Merges CLI→Env→TOML→Defaults
-├── config.py           # TOML file loading logic
+├── config.py           # TOML file loading logic, inherit_from, deep_merge
 ├── rule_builder.py     # Builds ValidationRule objects from config
-├── rules_catalog.py    # Catalog of all validation rules (COMMIT_RULES, BRANCH_RULES)
+├── rules_catalog.py    # Catalog of all validation rules (COMMIT_RULES, BRANCH_RULES, PUSH_RULES, FILES_RULES, TAG_RULES)
 ├── engine.py           # ValidationEngine orchestrates BaseValidator subclasses
-├── imperatives.py      # Imperative verb list for subject validation
+├── fixes.py            # Suggested fixes shown with a failure
+├── ai_signatures.py    # AI tool signature detection (data in ai_signatures_data.py)
+├── imperatives.py      # IMPERATIVES / NON_IMPERATIVE_LOOKALIKES sets for the subject-imperative stem test
 └── util.py             # Git operations, output formatting, helpers
 ```
 
-**Key Flow**: `main()` → `ConfigMerger` → `RuleBuilder` → `ValidationEngine` → `BaseValidator` subclasses → exit code 0/1
+**Key Flow**: `main()` → `ConfigMerger` → `RuleBuilder` → `ValidationEngine` → `BaseValidator` subclasses → exit code 0/1/2
 
 ### Configuration Discovery
 Tool searches for TOML files in this order:
@@ -54,7 +57,6 @@ python3 -m pip install nox
 
 # Install package in development mode with PYTHONPATH (network timeout workaround)
 export PYTHONPATH=/home/runner/work/commit-check/commit-check
-python3 -m pip install pyyaml  # Core dependency
 ```
 
 ### Build and Package
@@ -86,16 +88,6 @@ nox -s coverage  # NETWORK ISSUES: Often fails due to PyPI timeouts, takes 5+ mi
 python3 -m pip install pre-commit  # May timeout, retry if needed
 pre-commit install --hook-type pre-commit
 pre-commit run --all-files --show-diff-on-failure  # Takes 2-5 minutes for full run
-```
-
-### Documentation
-```bash
-# NETWORK ISSUES: Documentation builds fail due to external dependencies (fonts.google.com)
-# Install docs dependencies (may timeout)
-python3 -m pip install sphinx-immaterial sphinx-autobuild
-
-# Build docs -- FAILS due to network restrictions in CI environments
-PYTHONPATH=/home/runner/work/commit-check/commit-check sphinx-build -E -W -b html docs _build/html
 ```
 
 ## Validation Scenarios
@@ -165,10 +157,6 @@ cchk --help  # Verify alias works
 - **Issue**: nox sessions fail due to dependency installation timeouts
 - **Workaround**: Run commands directly with PYTHONPATH instead of nox sessions
 
-### Documentation
-- **Issue**: Sphinx build fails due to external font loading (fonts.google.com)
-- **Status**: Cannot be fixed in restricted CI environments
-
 ## Configuration and Important Files
 
 ### Repository Structure
@@ -177,18 +165,31 @@ cchk --help  # Verify alias works
 ├── commit_check/              # Main Python package
 │   ├── __init__.py           # Package constants, defaults (DEFAULT_COMMIT_TYPES, DEFAULT_BRANCH_TYPES)
 │   ├── main.py              # CLI entry point, StdinReader, argument parsing
+│   ├── api.py               # Public Python API (no subprocess)
 │   ├── config_merger.py     # ConfigMerger: CLI→Env→TOML→Defaults priority cascade
-│   ├── config.py            # TOML file loading (uses tomllib/tomli)
+│   ├── config.py            # TOML file loading (uses tomllib/tomli), inherit_from, deep_merge
 │   ├── rule_builder.py      # RuleBuilder: creates ValidationRule from config + catalog
-│   ├── rules_catalog.py     # COMMIT_RULES, BRANCH_RULES catalogs (RuleCatalogEntry)
+│   ├── rules_catalog.py     # COMMIT_RULES, BRANCH_RULES, PUSH_RULES, FILES_RULES, TAG_RULES (RuleCatalogEntry)
 │   ├── engine.py            # ValidationEngine, BaseValidator, ValidationContext
-│   ├── imperatives.py       # List of imperative verbs for subject validation
+│   ├── fixes.py             # Suggested fixes shown with a failure
+│   ├── ai_signatures.py     # AI tool signature detection
+│   ├── ai_signatures_data.py # Known AI tool signatures (pure data)
+│   ├── imperatives.py       # IMPERATIVES / NON_IMPERATIVE_LOOKALIKES sets for subject validation
 │   └── util.py              # Git operations, output formatting (_print_failure)
-├── tests/                    # Test suite (~564 tests in main_test.py alone)
+├── tests/                    # Test suite (13 *_test.py files; run pytest --co -q for the count)
 │   ├── main_test.py         # CLI integration tests
+│   ├── api_test.py          # Python API tests
 │   ├── engine_test.py       # Validator tests
+│   ├── engine_fixes_test.py # Suggested-fix output from validators
+│   ├── fixes_test.py        # fixes.py helpers
+│   ├── ai_signatures_test.py # AI signature detection (also the CodSpeed benchmarks)
+│   ├── config_test.py       # TOML loading and inherit_from
 │   ├── config_merger_test.py # Config merging tests
-│   └── rule_builder_test.py # Rule building tests
+│   ├── rule_builder_test.py # Rule building tests
+│   ├── rules_catalog_test.py # Rule ID contract
+│   ├── util_test.py         # Git helpers and output formatting
+│   ├── integration_test.py  # End-to-end CLI runs
+│   └── version_test.py      # Version string
 ├── assets/                   # README assets (demo recording)
 ├── cchk.toml                # Example TOML configuration (v2.0 format)
 ├── pyproject.toml           # Package metadata, build config, tool settings
@@ -198,7 +199,7 @@ cchk --help  # Verify alias works
 
 ### Key Files
 - **pyproject.toml**: Package metadata, dependencies, entry points (`commit-check` and `cchk`)
-- **noxfile.py**: Automated build tasks (lint, test, build, docs, coverage)
+- **noxfile.py**: Automated build tasks (lint, test-hook, build, install, commit-check, coverage)
 - **cchk.toml**: TOML configuration example for this repo
 - **commit_check/__init__.py**: DEFAULT_COMMIT_TYPES, DEFAULT_BRANCH_TYPES, DEFAULT_BOOLEAN_RULES
 - **commit_check/engine.py**: ValidationResult (PASS=0, FAIL=1), BaseValidator ABC
@@ -219,14 +220,14 @@ cchk --help  # Verify alias works
 
 ### Commit Message Validation
 - **Conventional Commits**: Enforces standard format: `type(scope): description`
-- **Supported types**: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+- **Default types**: feat, fix, docs, style, refactor, test, chore, perf, build, ci (commit.allow_commit_types). Revert commits are governed by allow_revert_commits, not a type.
 - **Scope**: Optional, e.g., `feat(api): add endpoint`
 - **Breaking changes**: Supports `!` notation: `feat!: breaking change`
 - **Merge commits**: Special handling for merge commit messages
 
 ### Branch Name Validation
 - **Conventional Branches**: Enforces patterns like `feature/`, `bugfix/`, etc.
-- **Allowed prefixes**: bugfix/, feature/, release/, hotfix/, task/, chore/
+- **Default prefixes**: feature, bugfix, hotfix, release, chore, feat, fix, build, ci, docs, perf, refactor, test, style, ai, claude, codex, copilot, cursor, dependabot, renovate (branch.allow_branch_types)
 - **Special branches**: master, main, HEAD, PR-* are allowed
 
 ### Author Validation
@@ -237,6 +238,7 @@ cchk --help  # Verify alias works
 ### Exit Codes
 - **0**: All checks passed
 - **1**: One or more checks failed
+- **2**: The run could not start (bad usage, unresolvable --rev, or a config file that is missing, invalid TOML, or names an unknown rule)
 - **Error output**: Colorized ASCII art rejection message with specific error details
 
 ## When to Use What

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -176,17 +176,18 @@ cchk --help  # Verify alias works
 │   ├── ai_signatures_data.py # Known AI tool signatures (pure data)
 │   ├── imperatives.py       # IMPERATIVES / NON_IMPERATIVE_LOOKALIKES sets for subject validation
 │   └── util.py              # Git operations, output formatting (_print_failure)
-├── tests/                    # Test suite (13 *_test.py files; run pytest --co -q for the count)
+├── tests/                    # Test suite (14 *_test.py files; run pytest --co -q for the count)
 │   ├── main_test.py         # CLI integration tests
 │   ├── api_test.py          # Python API tests
 │   ├── engine_test.py       # Validator tests
 │   ├── engine_fixes_test.py # Suggested-fix output from validators
 │   ├── fixes_test.py        # fixes.py helpers
-│   ├── ai_signatures_test.py # AI signature detection (also the CodSpeed benchmarks)
+│   ├── ai_signatures_test.py # AI signature detection
 │   ├── config_test.py       # TOML loading and inherit_from
 │   ├── config_merger_test.py # Config merging tests
 │   ├── rule_builder_test.py # Rule building tests
 │   ├── rules_catalog_test.py # Rule ID contract
+│   ├── readme_test.py       # README configuration table vs get_default_config()
 │   ├── util_test.py         # Git helpers and output formatting
 │   ├── integration_test.py  # End-to-end CLI runs
 │   └── version_test.py      # Version string

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
     rev: v2.1.0
     hooks:
     -   id: mypy
-        exclude: ^testing/resources/
 -   repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ and pre-commit resolves it against real tags when CI runs — so pointing it at 
 
 ## Git Rules
 
-- **Follow the Conventional Branch spec** for branch names: `<type>/<description>` with lowercase kebab-case descriptions. Allowed types: `feature/`, `bugfix/`, `hotfix/`, `release/`, `chore/`. Example: `chore/add-agent-guidelines`.
+- **Branch names.** This repository does not enforce branch naming (`cchk.toml` sets `conventional_branch = false`); CI only checks that the branch is rebased onto `main` (`require_rebase_target = "main"`). Prefer the Conventional Branch form `<type>/<kebab-case-description>` anyway, using any type in the tool's defaults (e.g. `feat/`, `fix/`, `chore/`, `docs/`, `claude/`). Example: `chore/add-agent-guidelines`.
 - **Follow the Conventional Commits spec** for commit messages: `<type>: <description>` (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`).
 - **No force push.** Never use `git push --force` or `git push --force-with-lease`.
 - **Additive commits only.** When addressing review feedback, add new commits on top. Never rebase, squash commits (e.g., do not use `git rebase -i` to squash history after the PR is open).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ CLI args / Env vars / TOML file
    BaseValidator subclasses  ← Each validator performs one focused check
            │
            ▼
-       Exit code 0/1
+   Exit code 0 / 1 (rejected) / 2 (config error)
 ```
 
 ### Module responsibilities
@@ -45,12 +45,16 @@ CLI args / Env vars / TOML file
 commit_check/
 ├── __init__.py          # Package constants: DEFAULT_COMMIT_TYPES, DEFAULT_BRANCH_TYPES, DEFAULT_BOOLEAN_RULES
 ├── main.py              # CLI entry point, argument parsing, StdinReader
-├── config.py            # TOML file loading (uses tomllib on Python 3.11+, tomli on older)
+├── api.py               # Public Python API (validate_message, validate_branch, ...) without a subprocess
+├── config.py            # TOML file loading (uses tomllib on Python 3.11+, tomli on older), inherit_from, deep_merge
 ├── config_merger.py     # ConfigMerger: merges CLI → Env → TOML → Defaults
 ├── rule_builder.py      # RuleBuilder: creates ValidationRule objects from config + catalog
-├── rules_catalog.py     # Catalog of all rules (COMMIT_RULES, BRANCH_RULES)
+├── rules_catalog.py     # Catalog of all rules (COMMIT_RULES, BRANCH_RULES, PUSH_RULES, FILES_RULES, TAG_RULES)
 ├── engine.py            # ValidationEngine, BaseValidator ABC, ValidationContext, ValidationResult
-├── imperatives.py       # ~258 English imperative verbs for subject validation
+├── fixes.py             # Suggested fixes printed with a failure (header, case, WIP, sign-off, branch type)
+├── ai_signatures.py     # detect_ai_signatures / has_ai_signature for the ai_attribution rule
+├── ai_signatures_data.py # Registry of known AI tool signatures (pure data)
+├── imperatives.py       # IMPERATIVES / NON_IMPERATIVE_LOOKALIKES sets used by the -s stem test in CC003 (not an allow-list)
 └── util.py              # Git operations, output formatting (_print_failure)
 ```
 
@@ -65,10 +69,14 @@ BaseValidator (ABC)
 │   └── SubjectLengthValidator          # Subject length min/max
 ├── AuthorValidator               # Author name and email format
 ├── BranchValidator               # Branch naming conventions
+├── TagValidator                  # Tag name pattern
+├── FilesValidator                # Committed file size, path pattern, path length
 ├── MergeBaseValidator            # Merge base / rebase target
 ├── SignoffValidator              # Signed-off-by trailer presence
 ├── BodyValidator                 # Commit body presence
-└── CommitTypeValidator           # Handles merge/revert/fixup/wip/empty commits
+├── ForcePushValidator            # Non-fast-forward push detection
+├── CommitTypeValidator           # Handles merge/revert/fixup/wip/empty commits
+└── AiAttributionValidator        # AI tool signatures in the message
 ```
 
 ### Configuration priority cascade
@@ -115,15 +123,11 @@ nox -s lint
 pre-commit install
 ```
 
-### Build documentation
+### Documentation
 
-```bash
-# One-time build
-nox -s docs
-
-# Live preview with auto-reload
-nox -s docs-live
-```
+The user documentation lives in a separate repository and is served from
+https://commit-check.com; this repository only carries `README.md`. There is no
+docs build session here.
 
 ### Test the pre-commit hook locally
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ variable that override it (priority: CLI > env > TOML > default). Booleans accep
 | `branch.allow_branch_names` | `[]` | `--allow-branch-names` | `CCHK_ALLOW_BRANCH_NAMES` | Extra whole branch names allowed besides `main`, `master`, `HEAD`, `PR-*` |
 | `branch.require_rebase_target` | `""` | `--require-rebase-target` | `CCHK_REQUIRE_REBASE_TARGET` | Branch the current branch must be rebased onto (CC202); empty disables |
 | `branch.ignore_authors` | `[]` | `--branch-ignore-authors` | `CCHK_BRANCH_IGNORE_AUTHORS` | Authors whose branches skip the branch checks |
-| `push.allow_force_push` | `true` | — (`--no-force-push` runs the check) | `CCHK_ALLOW_FORCE_PUSH` | Whether a force push is permitted (CC301); set `false` to reject non-fast-forward pushes |
+| `push.allow_force_push` | `true` | — (`--no-force-push` runs the check) | `CCHK_ALLOW_FORCE_PUSH` | Reserved; has no effect today. CC301 runs only with `--no-force-push`, which always rejects a non-fast-forward push |
 | `tag.regex` | SemVer with optional `v` | `--tag-regex` | `CCHK_TAG_REGEX` | Pattern tag names must match (CC401); empty disables |
 | `files.max_size` | `""` (off) | `--files-max-size` | `CCHK_FILES_MAX_SIZE` | Largest committed file, in bytes or with `KB`/`MB`/`GB` (CC302) |
 | `files.prohibited_patterns` | `[]` | `--files-prohibited-patterns` | `CCHK_FILES_PROHIBITED_PATTERNS` | fnmatch patterns committed paths must not match (CC303) |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   - [Use Custom Configuration File](#use-custom-configuration-file)
   - [Organization-Level Configuration (inherit_from)](#organization-level-configuration-inherit_from)
   - [Use CLI Arguments or Environment Variables](#use-cli-arguments-or-environment-variables)
+  - [Configuration reference](#configuration-reference)
   - [Check Push Safety](#check-push-safety)
   - [Exit Codes and Dry Run](#exit-codes-and-dry-run)
 - [AI-Native Usage](#ai-native-usage)
@@ -232,7 +233,49 @@ repos:
           - --author-email-pattern=^.+@example\.com$
 ```
 
-See the [Configuration documentation](https://commit-check.com/configuration/) for all available options.
+The table below lists every option; https://commit-check.com/configuration/ has the long-form rule descriptions.
+
+### Configuration reference
+
+Every setting, with its built-in default, the CLI flag and the `CCHK_*` environment
+variable that override it (priority: CLI > env > TOML > default). Booleans accept
+`true/false`, `yes/no`, `1/0`; lists are comma-separated on the CLI and in env vars.
+
+| Key | Default | CLI flag | Env var | Meaning |
+|-----|---------|----------|---------|---------|
+| `warn` (top level) | `[]` | — | — | Checks or rule IDs to report without failing the run (see "Report a rule without enforcing it") |
+| `commit.conventional_commits` | `true` | `--conventional-commits` | `CCHK_CONVENTIONAL_COMMITS` | Enforce the Conventional Commits format (CC001) |
+| `commit.message_pattern` | `""` | — | `CCHK_MESSAGE_PATTERN` | Custom regex the whole message must match; when set it replaces the Conventional Commits check (still reported as CC001) |
+| `commit.subject_capitalized` | `false` | `--subject-capitalized` | `CCHK_SUBJECT_CAPITALIZED` | Require the subject to start with a capital letter (CC002) |
+| `commit.subject_imperative` | `false` | `--subject-imperative` | `CCHK_SUBJECT_IMPERATIVE` | Require the subject to use the imperative mood (CC003) |
+| `commit.subject_max_length` | `80` | `--subject-max-length` | `CCHK_SUBJECT_MAX_LENGTH` | Maximum subject length (CC004) |
+| `commit.subject_min_length` | `5` | `--subject-min-length` | `CCHK_SUBJECT_MIN_LENGTH` | Minimum subject length (CC005) |
+| `commit.allow_commit_types` | `feat, fix, docs, style, refactor, test, chore, perf, build, ci` | `--allow-commit-types` | `CCHK_ALLOW_COMMIT_TYPES` | Allowed `<type>` values in the subject |
+| `commit.allow_merge_commits` | `true` | `--allow-merge-commits` | `CCHK_ALLOW_MERGE_COMMITS` | Allow merge commits (CC006) |
+| `commit.allow_revert_commits` | `true` | `--allow-revert-commits` | `CCHK_ALLOW_REVERT_COMMITS` | Allow revert commits (CC007) |
+| `commit.allow_empty_commits` | `true` | `--allow-empty-commits` | `CCHK_ALLOW_EMPTY_COMMITS` | Allow empty commit messages (CC008) |
+| `commit.allow_fixup_commits` | `true` | `--allow-fixup-commits` | `CCHK_ALLOW_FIXUP_COMMITS` | Allow `fixup!` commits (CC009) |
+| `commit.allow_wip_commits` | `true` | `--allow-wip-commits` | `CCHK_ALLOW_WIP_COMMITS` | Allow WIP commits (CC010) |
+| `commit.require_body` | `false` | `--require-body` | `CCHK_REQUIRE_BODY` | Require a commit body (CC011) |
+| `commit.require_signed_off_by` | `false` | `--require-signed-off-by` | `CCHK_REQUIRE_SIGNED_OFF_BY` | Require a `Signed-off-by:` trailer (CC012) |
+| `commit.ignore_authors` | `[]` | `--ignore-authors` | `CCHK_IGNORE_AUTHORS` | Authors and co-authors whose commits skip the commit checks |
+| `commit.ai_attribution` | `"ignore"` | `--ai-attribution` | `CCHK_AI_ATTRIBUTION` | `ignore` or `forbid`; `forbid` rejects commits carrying known AI tool signatures (CC013) |
+| `commit.author_email_pattern` | `"^.+@.+$"` | `--author-email-pattern` | `CCHK_AUTHOR_EMAIL_PATTERN` | Regex the author email must match (CC102, with `--author-email`) |
+| `commit.author_name_pattern` | `""` | `--author-name-pattern` | `CCHK_AUTHOR_NAME_PATTERN` | Regex the author name must match (CC101, with `--author-name`) |
+| `branch.conventional_branch` | `true` | `--conventional-branch` | `CCHK_CONVENTIONAL_BRANCH` | Enforce `<type>/<description>` branch names (CC201) |
+| `branch.allow_branch_types` | `feature, bugfix, hotfix, release, chore, feat, fix, build, ci, docs, perf, refactor, test, style, ai, claude, codex, copilot, cursor, dependabot, renovate` | `--allow-branch-types` | `CCHK_ALLOW_BRANCH_TYPES` | Allowed branch `<type>` prefixes |
+| `branch.allow_branch_names` | `[]` | `--allow-branch-names` | `CCHK_ALLOW_BRANCH_NAMES` | Extra whole branch names allowed besides `main`, `master`, `HEAD`, `PR-*` |
+| `branch.require_rebase_target` | `""` | `--require-rebase-target` | `CCHK_REQUIRE_REBASE_TARGET` | Branch the current branch must be rebased onto (CC202); empty disables |
+| `branch.ignore_authors` | `[]` | `--branch-ignore-authors` | `CCHK_BRANCH_IGNORE_AUTHORS` | Authors whose branches skip the branch checks |
+| `push.allow_force_push` | `true` | — (`--no-force-push` runs the check) | `CCHK_ALLOW_FORCE_PUSH` | Whether a force push is permitted (CC301); set `false` to reject non-fast-forward pushes |
+| `tag.regex` | SemVer with optional `v` | `--tag-regex` | `CCHK_TAG_REGEX` | Pattern tag names must match (CC401); empty disables |
+| `files.max_size` | `""` (off) | `--files-max-size` | `CCHK_FILES_MAX_SIZE` | Largest committed file, in bytes or with `KB`/`MB`/`GB` (CC302) |
+| `files.prohibited_patterns` | `[]` | `--files-prohibited-patterns` | `CCHK_FILES_PROHIBITED_PATTERNS` | fnmatch patterns committed paths must not match (CC303) |
+| `files.max_path_length` | `0` (off) | `--files-max-path-length` | `CCHK_FILES_MAX_PATH_LENGTH` | Longest allowed committed path, in characters (CC304) |
+
+Output/appearance is not configuration: `--format json`, `--no-banner`, `--compact`,
+`--dry-run`, `--rev`, `--config` are per-run flags, and color follows `NO_COLOR` /
+`FORCE_COLOR` (https://no-color.org).
 
 ### Check Push Safety
 

--- a/commit_check/api.py
+++ b/commit_check/api.py
@@ -45,9 +45,10 @@ code branching on ``status == "fail"`` keeps working unchanged.
 
 from __future__ import annotations
 
-import copy
+from collections.abc import Collection
 from typing import Any
 
+from commit_check.config import deep_merge
 from commit_check.config_merger import get_default_config
 from commit_check.engine import (
     CheckOutcome,
@@ -57,6 +58,7 @@ from commit_check.engine import (
     overall_status,
 )
 from commit_check.rule_builder import RuleBuilder
+from commit_check.rules_catalog import BRANCH_CHECKS, MESSAGE_CHECKS
 
 
 # ---------------------------------------------------------------------------
@@ -75,7 +77,7 @@ def _build_result(outcomes: list[CheckOutcome]) -> dict[str, Any]:
 
 
 def _run_checks(
-    check_names: list[str],
+    check_names: Collection[str],
     context: ValidationContext,
     config: dict[str, Any],
 ) -> dict[str, Any]:
@@ -92,12 +94,7 @@ def _merge_config(user_config: dict[str, Any] | None) -> dict[str, Any]:
     """Return the effective config: user overrides merged on top of defaults."""
     base = get_default_config()
     if user_config:
-        from commit_check.config_merger import deep_merge
-
-        # deep_copy the user config so that deep_merge cannot mutate the
-        # caller's dict (deep_merge operates in-place on `base`, and may
-        # assign nested objects from `override` directly into `base`).
-        deep_merge(base, copy.deepcopy(user_config))
+        deep_merge(base, user_config)
     return base
 
 
@@ -132,22 +129,7 @@ def validate_message(
     """
     cfg = _merge_config(config)
     context = ValidationContext(stdin_text=message.strip(), config=cfg)
-    check_names = [
-        "message",
-        "subject_imperative",
-        "subject_max_length",
-        "subject_min_length",
-        "subject_capitalized",
-        "require_signed_off_by",
-        "require_body",
-        "allow_merge_commits",
-        "allow_revert_commits",
-        "allow_empty_commits",
-        "allow_fixup_commits",
-        "allow_wip_commits",
-        "ai_attribution",
-    ]
-    return _run_checks(check_names, context, cfg)
+    return _run_checks(MESSAGE_CHECKS, context, cfg)
 
 
 def validate_branch(
@@ -177,7 +159,7 @@ def validate_branch(
         stdin_text=branch.strip() if branch else None,
         config=cfg,
     )
-    return _run_checks(["branch", "merge_base"], context, cfg)
+    return _run_checks(BRANCH_CHECKS, context, cfg)
 
 
 def validate_tag(

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 from typing import Any
 from pathlib import Path
+import copy
+import io
 import sys
 import urllib.request
 import urllib.error
@@ -35,15 +37,20 @@ DEFAULT_CONFIG_PATHS = [
 ]
 
 
-def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-    """Deep merge override into base, returning a new dict."""
-    result = dict(base)
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
+    """Deep merge *override* into *base*, modifying *base* in place.
+
+    Nested dicts from *override* are copied before being assigned, so the
+    caller's dict is never aliased into *base*: a later merge into *base*
+    cannot reach back and change what the caller passed in.
+    """
     for key, value in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = _deep_merge(result[key], value)
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            deep_merge(base[key], value)
+        elif isinstance(value, dict):
+            base[key] = copy.deepcopy(value)
         else:
-            result[key] = value
-    return result
+            base[key] = value
 
 
 def _github_shorthand_to_url(value: str) -> str | None:
@@ -138,8 +145,6 @@ def _load_from_url(url: str) -> dict[str, Any]:
         raise ValueError("only https:// URLs are accepted")
     with _opener.open(url, timeout=10) as response:  # noqa: S310
         data = response.read()
-    import io
-
     return toml_load(io.BytesIO(data))
 
 
@@ -196,7 +201,8 @@ def _resolve_inherit_from(config: dict[str, Any]) -> dict[str, Any]:
         parent = {}
 
     if parent:
-        return _deep_merge(parent, config)
+        deep_merge(parent, config)
+        return parent
     return config
 
 

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -40,17 +40,16 @@ DEFAULT_CONFIG_PATHS = [
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
     """Deep merge *override* into *base*, modifying *base* in place.
 
-    Nested dicts from *override* are copied before being assigned, so the
-    caller's dict is never aliased into *base*: a later merge into *base*
-    cannot reach back and change what the caller passed in.
+    Every value taken from *override* is copied before being assigned, so
+    nothing the caller passed in (a nested dict or a list such as
+    ``prohibited_patterns``) is ever aliased into *base*: a later change to
+    *base* cannot reach back and change the caller's config.
     """
     for key, value in override.items():
         if key in base and isinstance(base[key], dict) and isinstance(value, dict):
             deep_merge(base[key], value)
-        elif isinstance(value, dict):
-            base[key] = copy.deepcopy(value)
         else:
-            base[key] = value
+            base[key] = copy.deepcopy(value)
 
 
 def _github_shorthand_to_url(value: str) -> str | None:

--- a/commit_check/config_merger.py
+++ b/commit_check/config_merger.py
@@ -7,7 +7,7 @@ import argparse
 from collections.abc import Callable
 from typing import Any
 
-from commit_check.config import load_config as load_toml_config
+from commit_check.config import deep_merge, load_config as load_toml_config
 from commit_check import (
     DEFAULT_COMMIT_TYPES,
     DEFAULT_BRANCH_TYPES,
@@ -102,15 +102,6 @@ def get_default_config() -> dict[str, Any]:
             "max_path_length": 0,
         },
     }
-
-
-def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
-    """Deep merge override into base dictionary (modifies base in-place)."""
-    for key, value in override.items():
-        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
-            deep_merge(base[key], value)
-        else:
-            base[key] = value
 
 
 class ConfigMerger:

--- a/commit_check/engine.py
+++ b/commit_check/engine.py
@@ -1,18 +1,23 @@
 """Clean validation engine following SOLID principles."""
 
 from __future__ import annotations
+import re
 import shlex
+import subprocess
+import sys
 from abc import ABC, abstractmethod
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import IntEnum
 from dataclasses import field
+from fnmatch import fnmatchcase
 
 from commit_check.rule_builder import ValidationRule
 from commit_check.ai_signatures import (
     detect_ai_signatures,
 )
 from commit_check.util import (
+    _print_failure,
     fetch_remote_ref,
     fetch_upstream_ref,
     get_commit_author_identity,
@@ -30,6 +35,8 @@ from commit_check.util import (
     has_commits,
     git_merge_base,
     git_rev_parse_verify,
+    print_error_header,
+    rejection_headline,
 )
 from commit_check.imperatives import IMPERATIVES, NON_IMPERATIVE_LOOKALIKES
 from commit_check.fixes import (
@@ -263,8 +270,6 @@ class BaseValidator(ABC):
 
     def _author_in_ignore_list(self, context: ValidationContext) -> bool:
         """Check if the current author or any co-author is in the ignore list."""
-        import re
-
         ignore_authors = context.config.get("commit", {}).get("ignore_authors", [])
         if not ignore_authors:
             return False
@@ -372,8 +377,6 @@ class BaseValidator(ABC):
         self._failure_blocks.append((rule_dict, actual_value))
 
         if not self._suppress_output:
-            from commit_check.util import _print_failure
-
             _print_failure(
                 rule_dict,
                 actual_value,
@@ -394,8 +397,6 @@ class CommitMessageValidator(BaseValidator):
             return ValidationResult.PASS
 
         self._checked_value = message
-
-        import re
 
         if self.rule.regex and re.match(self.rule.regex, message):
             return ValidationResult.PASS
@@ -482,8 +483,6 @@ class SubjectCapitalizationValidator(SubjectValidator):
         "A" and not on the "f" that follows, and "Update" alone is judged at
         all.
         """
-        import re
-
         match = re.match(r"^\w+(?:\([^)]*\))?!?:\s*(.*)", subject)
         description = match.group(1).strip() if match else subject
         return bool(description) and description[0].isupper()
@@ -513,8 +512,6 @@ class SubjectImperativeValidator(SubjectValidator):
             return ValidationResult.SKIP
 
         # Extract first word (ignore conventional commit prefixes)
-        import re
-
         # support breaking changes (feat!:)
         match = re.match(r"^(?:\w+(?:\([^)]*\))?!?:\s*)?(\w+)", subject)
         if not match:
@@ -648,8 +645,6 @@ class AuthorValidator(BaseValidator):
     def _validate_author(self, author_value: str) -> ValidationResult:
         """Validate author against rule constraints."""
         if self.rule.regex:
-            import re
-
             if re.match(self.rule.regex, author_value):
                 return ValidationResult.PASS
             self._print_failure(author_value)
@@ -681,8 +676,6 @@ class BranchValidator(BaseValidator):
 
         if not self.rule.regex:
             return ValidationResult.PASS
-
-        import re
 
         if re.match(self.rule.regex, branch_name):
             return ValidationResult.PASS
@@ -747,8 +740,6 @@ class TagValidator(BaseValidator):
 
         if not self.rule.regex:
             return ValidationResult.PASS
-
-        import re
 
         for tag in tags:
             if not re.match(self.rule.regex, tag):
@@ -886,8 +877,6 @@ class FilesValidator(BaseValidator):
         # "*.pem" catch KEY.PEM on Windows and miss it everywhere else --
         # one config, two policies. fnmatchcase() is the same on every
         # platform, and case-sensitive is what git pathspecs already are.
-        from fnmatch import fnmatchcase
-
         patterns = self.rule.value or []
         offenders = []
         for path, _ in files:
@@ -976,8 +965,6 @@ class MergeBaseValidator(BaseValidator):
             ``"^main$"`` or ``"main"``).
         :returns: The resolved branch name if verified, ``None`` otherwise.
         """
-        import subprocess
-
         # Strip common regex anchors to obtain a clean branch name
         branch_name = pattern.lstrip("^").rstrip("$").strip()
         if not branch_name:
@@ -1029,8 +1016,6 @@ class SignoffValidator(BaseValidator):
             return ValidationResult.PASS
 
         self._checked_value = message
-
-        import re
 
         if self.rule.regex and re.search(self.rule.regex, message):
             return ValidationResult.PASS
@@ -1457,12 +1442,6 @@ class ValidationEngine:
         if not blocks:
             return
 
-        from commit_check.util import (
-            _print_failure,
-            print_error_header,
-            rejection_headline,
-        )
-
         # Only an enforced failure earns the banner; a warning rejects
         # nothing. --compact and --no-banner keep it off entirely.
         if (
@@ -1483,8 +1462,6 @@ class ValidationEngine:
     @staticmethod
     def _print_notices(skipped: list[str], warned: list[str]) -> None:
         """Name the skipped and the warning checks on stderr."""
-        import sys
-
         if skipped:
             # A skipped check validated nothing, and a silent skip is
             # indistinguishable from a pass — which is how a merge commit at

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 import json
 import os
+import select
 import sys
 import argparse
 
 from commit_check.config import ConfigError, find_config_path
 from commit_check.config_merger import ConfigMerger, parse_bool, parse_list, parse_int
 from commit_check.rule_builder import RuleBuilder
+from commit_check.rules_catalog import BRANCH_CHECKS, FILES_CHECKS, MESSAGE_CHECKS
+from commit_check.util import (
+    get_remote_branch_sha,
+    git_rev_parse_verify,
+    print_error_header,
+)
 from commit_check.engine import (
     ValidationEngine,
     ValidationContext,
@@ -49,7 +56,6 @@ class StdinReader:
             # blocking read there; the hang has only been observed on POSIX
             # runners, and a wrong guess here would break piping instead.
             return True
-        import select
 
         try:
             ready, _, _ = select.select([sys.stdin], [], [], timeout)
@@ -106,8 +112,6 @@ def _build_pre_commit_push_input() -> str | None:
         return None
 
     if remote_name:
-        from commit_check.util import get_remote_branch_sha
-
         remote_branch = remote_ref.removeprefix("refs/heads/")
         remote_sha = get_remote_branch_sha(remote_name, remote_branch)
 
@@ -540,40 +544,28 @@ def _resolve_stdin_for_non_message(
     return stdin_content
 
 
-def _get_requested_checks(args: argparse.Namespace) -> list[str]:
-    """Build the list of requested validation checks based on CLI args."""
-    requested_checks: list[str] = []
+def _get_requested_checks(args: argparse.Namespace) -> set[str]:
+    """The validation checks the CLI flags request.
+
+    Only membership matters: rules run in catalog order, and this set is what
+    the built rules are filtered against.
+    """
+    requested_checks: set[str] = set()
 
     if args.message:
-        requested_checks.extend(
-            [
-                "message",
-                "subject_imperative",
-                "subject_max_length",
-                "subject_min_length",
-                "require_signed_off_by",
-                "subject_capitalized",
-                "require_body",
-                "allow_merge_commits",
-                "allow_revert_commits",
-                "allow_empty_commits",
-                "allow_fixup_commits",
-                "allow_wip_commits",
-                "ai_attribution",
-            ]
-        )
+        requested_checks |= MESSAGE_CHECKS
     if args.branch:
-        requested_checks.extend(["branch", "merge_base"])
+        requested_checks |= BRANCH_CHECKS
     if args.tag:
-        requested_checks.append("tag")
+        requested_checks.add("tag")
     if args.files:
-        requested_checks.extend(["file_size", "file_pattern", "path_length"])
+        requested_checks |= FILES_CHECKS
     if args.author_name:
-        requested_checks.append("author_name")
+        requested_checks.add("author_name")
     if args.author_email:
-        requested_checks.append("author_email")
+        requested_checks.add("author_email")
     if args.no_force_push:
-        requested_checks.append("no_force_push")
+        requested_checks.add("no_force_push")
 
     return requested_checks
 
@@ -634,8 +626,6 @@ def main() -> int:
                 )
             # Fail here, with the revision named, rather than deep inside a
             # validator where the error would surface as a missing message.
-            from commit_check.util import git_rev_parse_verify
-
             if not git_rev_parse_verify(args.rev):
                 print(
                     f"Error: --rev {args.rev!r} does not resolve to a commit "
@@ -697,9 +687,7 @@ def main() -> int:
                 stdin_content = _resolve_stdin_for_non_message(args, stdin_reader)
 
         # Reset banner state for this run
-        from commit_check.util import print_error_header as _peh
-
-        _peh.has_been_called = False
+        print_error_header.has_been_called = False
 
         context = ValidationContext(
             stdin_text=stdin_content,

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -7,6 +7,7 @@ from typing import Any
 from dataclasses import dataclass, replace
 from functools import lru_cache
 from commit_check.config import ConfigError
+from commit_check.util import format_size, parse_size
 from commit_check.rules_catalog import (
     COMMIT_RULES,
     BRANCH_RULES,
@@ -269,8 +270,6 @@ class RuleBuilder:
         catalog_entry: RuleCatalogEntry, files_config: dict[str, Any]
     ) -> ValidationRule | None:
         """Build the file size rule when max_size parses to a usable limit."""
-        from commit_check.util import format_size, parse_size
-
         max_size = parse_size(files_config.get("max_size"))
         if max_size is None:
             return None

--- a/commit_check/rules_catalog.py
+++ b/commit_check/rules_catalog.py
@@ -276,3 +276,16 @@ ALL_RULES = [
 #: Lookup from check name to its catalog entry, for rules that have an ID.
 #: Rule identity lives only here, so built rules can never carry a stale copy.
 RULES_BY_CHECK = {entry.check: entry for entry in ALL_RULES}
+
+#: The checks each CLI flag or API function requests. The catalog is the only
+#: place that knows which checks exist, so the grouping lives beside it rather
+#: than as a list copied into ``main.py`` and ``api.py`` that could drift.
+#: ``--message`` runs every commit rule except the author ones (they have
+#: their own flags) and the ``ignore_authors`` bookkeeping entry.
+MESSAGE_CHECKS: frozenset[str] = frozenset(
+    entry.check
+    for entry in COMMIT_RULES
+    if entry.check not in {"author_name", "author_email", "ignore_authors"}
+)
+BRANCH_CHECKS: frozenset[str] = frozenset({"branch", "merge_base"})
+FILES_CHECKS: frozenset[str] = frozenset(entry.check for entry in FILES_RULES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ python_version = "3.10"
 show_error_codes = true
 show_column_numbers = true
 
-[tool.coverage]
+[tool.coverage.run]
 omit = [
     # don't include tests in coverage
     "tests/*",

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -15,6 +15,20 @@ from commit_check.api import (
 class TestValidateMessage:
     """Tests for validate_message()."""
 
+    def test_caller_config_is_not_modified_or_aliased(self):
+        """The caller's config, lists included, is untouched after a call."""
+        import copy
+
+        config = {
+            "commit": {"allow_commit_types": ["feat", "fix"]},
+            "files": {"prohibited_patterns": ["*.pem"]},
+        }
+        snapshot = copy.deepcopy(config)
+        validate_message("feat: add thing", config=config)
+        assert config == snapshot
+        validate_message("chore: add thing", config=config)
+        assert config == snapshot
+
     @pytest.mark.benchmark
     def test_valid_conventional_commit_passes(self):
         """A well-formed conventional commit message returns status='pass'."""

--- a/tests/config_merger_test.py
+++ b/tests/config_merger_test.py
@@ -140,6 +140,12 @@ class TestDeepMerge:
         deep_merge(base, override)
         assert base == {"section": "not_a_dict"}
 
+    def test_reexported_from_config(self):
+        """config_merger keeps the historical import path working."""
+        from commit_check import config
+
+        assert deep_merge is config.deep_merge
+
 
 class TestConfigMergerParseEnvVars:
     """Tests for ConfigMerger.parse_env_vars method."""

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -560,6 +560,15 @@ class TestDeepMerge:
         base["files"]["max_size"] = "1MB"
         assert override == {"files": {"prohibited_patterns": ["*.pem"]}}
 
+    def test_deep_merge_does_not_alias_lists_into_existing_sections(self):
+        """A list override into a section *base* already has is copied too."""
+        override = {"files": {"prohibited_patterns": ["*.pem"]}}
+        base: dict = {"files": {"max_size": "1MB"}}
+        deep_merge(base, override)
+        assert base == {"files": {"max_size": "1MB", "prohibited_patterns": ["*.pem"]}}
+        base["files"]["prohibited_patterns"].append("*.key")
+        assert override == {"files": {"prohibited_patterns": ["*.pem"]}}
+
     def test_deep_merge_replaces_non_dict_with_copied_dict(self):
         base = {"section": "scalar"}
         override = {"section": {"key": ["v"]}}

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -10,7 +10,7 @@ from commit_check.config import (
     ConfigError,
     load_config,
     DEFAULT_CONFIG_PATHS,
-    _deep_merge,
+    deep_merge,
     _resolve_inherit_from,
     _load_from_url,
     _github_shorthand_to_url,
@@ -526,30 +526,46 @@ value = "test"
 
 
 class TestDeepMerge:
-    """Tests for the _deep_merge helper."""
+    """Tests for the deep_merge helper."""
 
     @pytest.mark.benchmark
     def test_deep_merge_simple(self):
         base = {"a": 1, "b": 2}
         override = {"b": 3, "c": 4}
-        result = _deep_merge(base, override)
-        assert result == {"a": 1, "b": 3, "c": 4}
+        assert deep_merge(base, override) is None
+        assert base == {"a": 1, "b": 3, "c": 4}
 
     @pytest.mark.benchmark
     def test_deep_merge_nested(self):
         base = {"commit": {"conventional_commits": True, "subject_max_length": 80}}
         override = {"commit": {"subject_max_length": 72}}
-        result = _deep_merge(base, override)
-        assert result["commit"]["conventional_commits"] is True
-        assert result["commit"]["subject_max_length"] == 72
+        deep_merge(base, override)
+        assert base["commit"]["conventional_commits"] is True
+        assert base["commit"]["subject_max_length"] == 72
 
     @pytest.mark.benchmark
-    def test_deep_merge_does_not_mutate_base(self):
+    def test_deep_merge_merges_nested_in_place(self):
         base = {"a": {"x": 1}}
         override = {"a": {"y": 2}}
-        _deep_merge(base, override)
-        # _deep_merge returns a new dict; base itself may be used but result is new
-        assert _deep_merge(base, override)["a"] == {"x": 1, "y": 2}
+        deep_merge(base, override)
+        assert base["a"] == {"x": 1, "y": 2}
+
+    def test_deep_merge_does_not_alias_new_nested_dicts(self):
+        """A nested dict only in *override* is copied, not shared."""
+        override = {"files": {"prohibited_patterns": ["*.pem"]}}
+        base: dict = {}
+        deep_merge(base, override)
+        assert base == override
+        base["files"]["prohibited_patterns"].append("*.key")
+        base["files"]["max_size"] = "1MB"
+        assert override == {"files": {"prohibited_patterns": ["*.pem"]}}
+
+    def test_deep_merge_replaces_non_dict_with_copied_dict(self):
+        base = {"section": "scalar"}
+        override = {"section": {"key": ["v"]}}
+        deep_merge(base, override)
+        assert base["section"] is not override["section"]
+        assert base == {"section": {"key": ["v"]}}
 
 
 class TestResolveInheritFrom:

--- a/tests/engine_test.py
+++ b/tests/engine_test.py
@@ -617,7 +617,7 @@ class TestAuthorValidator:
 
         # Mock author value and print function
         with patch.object(validator, "_get_author_value", return_value="Unknown User"):
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 context = ValidationContext()
                 result = validator.validate(context)
                 assert result == ValidationResult.FAIL
@@ -668,7 +668,7 @@ class TestAuthorPatternConfig:
     @staticmethod
     def _validate(rule, author_value):
         validator = AuthorValidator(rule)
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             return validator.validate(ValidationContext(stdin_text=author_value))
 
     @pytest.mark.benchmark
@@ -854,7 +854,7 @@ class TestCommitTypeValidator:
                 "an": "test-author",
             }[x]
 
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
                 assert result == ValidationResult.FAIL
 
@@ -889,7 +889,7 @@ class TestCommitTypeValidator:
                 "an": "test-author",
             }[x]
 
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
                 assert result == ValidationResult.FAIL
 
@@ -1066,7 +1066,7 @@ class TestSignoffValidator:
         validator = SignoffValidator(self._default_signoff_rule())
         context = ValidationContext(stdin_text="feat: add feature")
 
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = validator.validate(context)
         assert result == ValidationResult.FAIL
 
@@ -1166,7 +1166,7 @@ class TestSignoffValidator:
         validator = SignoffValidator(rule)
         context = ValidationContext(stdin_text="feat: add feature")
 
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
 
@@ -1257,7 +1257,7 @@ class TestBodyValidator:
         validator = BodyValidator(rule)
         context = ValidationContext(stdin_text="feat: add feature")
 
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
 
@@ -1273,7 +1273,7 @@ class TestBodyValidator:
         validator = BodyValidator(rule)
         context = ValidationContext(stdin_text="\n\nbody content")
 
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
 
@@ -1753,7 +1753,7 @@ class TestValidationEngine:
         engine = ValidationEngine(rules)
         context = ValidationContext(stdin_text="feat: add new feature")
 
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = engine.validate_all(context)
             assert result == ValidationResult.FAIL  # Any failure = overall failure
 
@@ -1956,7 +1956,7 @@ class TestSubjectImperativeValidator:
         context = ValidationContext(stdin_text="fix: resolved the issue")
 
         # Mock the print function to avoid output during tests
-        with patch("commit_check.util._print_failure"):
+        with patch("commit_check.engine._print_failure"):
             result = validator.validate(context)
             assert result == ValidationResult.FAIL
 
@@ -2032,7 +2032,7 @@ class TestCoAuthorSkip:
         context = ValidationContext(stdin_text=message, config=config)
 
         with patch("commit_check.engine.get_commit_info", return_value="other-author"):
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
         assert result == ValidationResult.FAIL
 
@@ -2193,7 +2193,7 @@ class TestGetGitConfigValue:
                 return_value="01 Invalid Name",
             ),
         ):
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
         assert result == ValidationResult.FAIL
 
@@ -2394,7 +2394,7 @@ class TestForcePushValidator:
                     with patch(
                         "commit_check.engine.git_merge_base", return_value=1
                     ) as mock_merge:
-                        with patch("commit_check.util._print_failure"):
+                        with patch("commit_check.engine._print_failure"):
                             result = validator.validate(context)
 
         mock_merge.assert_called_once_with("deadbeef", "HEAD")
@@ -2420,7 +2420,7 @@ class TestForcePushValidator:
                         with patch(
                             "commit_check.engine.fetch_upstream_ref", return_value=True
                         ) as mock_fetch:
-                            with patch("commit_check.util._print_failure"):
+                            with patch("commit_check.engine._print_failure"):
                                 result = validator.validate(context)
 
         mock_fetch.assert_called_once_with("origin/main")
@@ -2462,7 +2462,7 @@ class TestForcePushValidator:
         context = ValidationContext(stdin_text=push_info)
 
         with patch("commit_check.engine.git_merge_base", return_value=1):
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
 
         assert result == ValidationResult.FAIL
@@ -2500,7 +2500,7 @@ class TestForcePushValidator:
             with patch("commit_check.engine.get_upstream_branch", return_value=""):
                 with patch(GET_GIT_REMOTES, return_value=["origin"]):
                     with patch(FETCH_REMOTE_REF, return_value=True) as mock_fetch:
-                        with patch("commit_check.util._print_failure"):
+                        with patch("commit_check.engine._print_failure"):
                             result = validator.validate(context)
 
         assert mock_merge.call_count == 2
@@ -2546,7 +2546,7 @@ class TestForcePushValidator:
                     return_value=["origin", "upstream"],
                 ):
                     with patch(FETCH_REMOTE_REF, return_value=True) as mock_fetch:
-                        with patch("commit_check.util._print_failure"):
+                        with patch("commit_check.engine._print_failure"):
                             result = validator.validate(context)
 
         assert mock_merge.call_count == 3
@@ -2598,7 +2598,7 @@ class TestForcePushValidator:
             return 1
 
         with patch("commit_check.engine.git_merge_base", side_effect=side_effect):
-            with patch("commit_check.util._print_failure"):
+            with patch("commit_check.engine._print_failure"):
                 result = validator.validate(context)
 
         assert result == ValidationResult.FAIL

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -515,7 +515,8 @@ class TestMainFunctionEdgeCases:
         assert str(cfg) in err
         assert "line 1" in err
 
-    @pytest.mark.benchmark
+    # No benchmark mark: CodSpeed executes marked tests more than once against
+    # the same tmp_path, and the mkdir below only works on a fresh one.
     def test_invalid_default_config_names_the_file_too(
         self, mocker, capsys, monkeypatch, tmp_path
     ):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1322,14 +1322,14 @@ class TestTagFlag:
         from commit_check.main import _get_parser, _get_requested_checks
 
         args = _get_parser().parse_args(["-t"])
-        assert _get_requested_checks(args) == ["tag"]
+        assert _get_requested_checks(args) == {"tag"}
 
     def test_tag_combines_with_branch(self):
         """-b -t requests branch, merge_base and tag checks."""
         from commit_check.main import _get_parser, _get_requested_checks
 
         args = _get_parser().parse_args(["-b", "-t"])
-        assert _get_requested_checks(args) == ["branch", "merge_base", "tag"]
+        assert _get_requested_checks(args) == {"branch", "merge_base", "tag"}
 
     def test_tag_regex_reaches_config(self):
         """--tag-regex overrides the [tag] section pattern."""
@@ -1358,11 +1358,11 @@ class TestFilesFlag:
         from commit_check.main import _get_parser, _get_requested_checks
 
         args = _get_parser().parse_args(["-f"])
-        assert _get_requested_checks(args) == [
+        assert _get_requested_checks(args) == {
             "file_size",
             "file_pattern",
             "path_length",
-        ]
+        }
 
     def test_files_cli_options_reach_config(self):
         from commit_check.main import _get_parser

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -34,11 +34,21 @@ def test_every_default_key_is_in_readme(readme_text, dotted_key):
     )
 
 
+def _table_row(readme_text: str, dotted_key: str) -> str:
+    """The configuration-reference row for ``dotted_key`` (empty if absent)."""
+    prefix = f"| `{dotted_key}` |"
+    return next(
+        (line for line in readme_text.splitlines() if line.startswith(prefix)), ""
+    )
+
+
 @pytest.mark.parametrize("env_var", sorted(ConfigMerger.ENV_VAR_MAPPING))
 def test_every_env_var_is_in_readme(readme_text, env_var):
-    """Each ``CCHK_*`` variable the merger reads is documented."""
-    assert f"`{env_var}`" in readme_text, (
-        f"{env_var} is missing from the README configuration reference"
+    """Each ``CCHK_*`` variable is documented on the row of the key it sets."""
+    section, key, _parser = ConfigMerger.ENV_VAR_MAPPING[env_var]
+    row = _table_row(readme_text, f"{section}.{key}")
+    assert f"`{env_var}`" in row, (
+        f"{env_var} is missing from the README row for {section}.{key}"
     )
 
 

--- a/tests/readme_test.py
+++ b/tests/readme_test.py
@@ -1,0 +1,47 @@
+"""The README's configuration reference must name every setting the tool has.
+
+The table is static Markdown, so nothing regenerates it; this is what keeps a
+new key in ``get_default_config()`` from going undocumented.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from commit_check.config_merger import ConfigMerger, get_default_config
+
+README = Path(__file__).resolve().parent.parent / "README.md"
+
+
+@pytest.fixture(scope="module")
+def readme_text() -> str:
+    return README.read_text(encoding="utf-8")
+
+
+def _default_keys() -> list[str]:
+    return [
+        f"{section}.{key}"
+        for section, keys in get_default_config().items()
+        for key in keys
+    ]
+
+
+@pytest.mark.parametrize("dotted_key", _default_keys())
+def test_every_default_key_is_in_readme(readme_text, dotted_key):
+    """Each ``section.key`` from the defaults appears as a table row."""
+    assert f"| `{dotted_key}` |" in readme_text, (
+        f"{dotted_key} is missing from the README configuration reference"
+    )
+
+
+@pytest.mark.parametrize("env_var", sorted(ConfigMerger.ENV_VAR_MAPPING))
+def test_every_env_var_is_in_readme(readme_text, env_var):
+    """Each ``CCHK_*`` variable the merger reads is documented."""
+    assert f"`{env_var}`" in readme_text, (
+        f"{env_var} is missing from the README configuration reference"
+    )
+
+
+def test_top_level_warn_is_in_readme(readme_text):
+    """``warn`` is not in the defaults dict, so it is checked by name."""
+    assert "| `warn` (top level) |" in readme_text

--- a/tests/rules_catalog_test.py
+++ b/tests/rules_catalog_test.py
@@ -11,8 +11,12 @@ import pytest
 from commit_check.rules_catalog import (
     ALL_RULES,
     RULES_BY_CHECK,
+    BRANCH_CHECKS,
     BRANCH_RULES,
     COMMIT_RULES,
+    FILES_CHECKS,
+    FILES_RULES,
+    MESSAGE_CHECKS,
     PUSH_RULES,
     RULES_DOCS_URL,
     RuleCatalogEntry,
@@ -134,3 +138,23 @@ class TestRuleIdPropagation:
         rule = next(r for r in rules if r.check == "ignore_authors")
         assert rule.rule_id is None
         assert rule.docs_url is None
+
+
+class TestCheckGroups:
+    """The check groups the CLI flags and API functions request."""
+
+    def test_message_checks_are_commit_rules(self):
+        """Every message check is a catalog entry, so none can be a typo."""
+        assert MESSAGE_CHECKS <= {entry.check for entry in COMMIT_RULES}
+
+    def test_message_checks_cover_every_commit_rule_but_author_ones(self):
+        """A new commit rule joins --message automatically."""
+        left_out = {entry.check for entry in COMMIT_RULES} - MESSAGE_CHECKS
+        assert left_out == {"author_name", "author_email", "ignore_authors"}
+
+    def test_branch_checks_are_branch_rules(self):
+        assert BRANCH_CHECKS <= {entry.check for entry in BRANCH_RULES}
+        assert "ignore_authors" not in BRANCH_CHECKS
+
+    def test_files_checks_are_every_files_rule(self):
+        assert FILES_CHECKS == {entry.check for entry in FILES_RULES}


### PR DESCRIPTION
## What

Three commits: two documentation, one behaviour-neutral refactor, plus three follow-ups (CodeRabbit's review, the adversarial review of this PR, and a red CodSpeed job). No CLI output changes: 123 CLI scenarios and 320 Python API calls compared byte for byte between `main` and this branch, the only difference being `--version` reading a stale egg-info in the sandbox.

### README: a configuration reference table
Of the 28 keys in `get_default_config()`, 9 never appeared in the README (`message_pattern`, `allow_revert_commits`, `allow_empty_commits`, `allow_fixup_commits`, `require_body`, `author_email_pattern`, `author_name_pattern`, `require_rebase_target`, `allow_force_push`) and none was shown with its default, CLI flag and `CCHK_*` environment variable together; the section deferred to the website. A new "Configuration reference" subsection (after "Use CLI Arguments or Environment Variables", in the TOC) lists all 28 keys plus the top-level `warn`, each with default, flag, env var, meaning and rule ID. The table was generated from `get_default_config()`, `ENV_VAR_MAPPING`, `CLI_ARG_MAPPING` and the argparse help, then committed as static Markdown; a new `tests/readme_test.py` asserts every `section.key` is a table row, every `CCHK_*` variable sits on the row of the key it sets (looked up through `ENV_VAR_MAPPING`), and the `warn` row is present, so the table cannot drift from the code. Every row's default, flag, env var and rule ID was re-verified programmatically during review.

One row is honest rather than flattering: `push.allow_force_push` is a pre-existing dead key. The value is never consulted (CC301 runs only with `--no-force-push`, which always rejects a force push), so the row says "Reserved; has no effect today" instead of describing behaviour that does not exist. Making the key work is a separate change.

### Contributor docs aligned with the code
- `CONTRIBUTING.md`: the `nox -s docs` / `docs-live` sessions were removed in #519 along with `docs/`; the section now says where the docs live. "~258 imperative verbs" → the set has 526 entries and is not an allow-list. Module and validator trees completed (api, fixes, ai_signatures; Tag/Files/ForcePush/AiAttribution validators); exit codes 0 / 1 / 2.
- `.github/copilot-instructions.md`: "~564 tests in main_test.py" → 97 (888 total); default commit types no longer list `revert` (a revert is governed by `allow_revert_commits`); default branch prefixes no longer list `task/`; the `pip install pyyaml` line and two Sphinx build blocks are gone; the noxfile session list and exit-code list match reality; 14 test files listed including `readme_test.py`, and the CodSpeed benchmarks are no longer attributed to one file (11 of 14 files carry them).
- `AGENTS.md`: the branch-naming rule listed five types while `cchk.toml` sets `conventional_branch = false`, so CI only checks `require_rebase_target = "main"`. The sentence now says exactly that and recommends the Conventional Branch form without pretending it is enforced.
- `pyproject.toml`: `[tool.coverage] omit` is not a table coverage.py reads (`coverage debug config` showed `run_omit: -none-`); it is now `[tool.coverage.run]`. No coverage number changes because nox already passes `--source`.
- `.pre-commit-config.yaml`: the mypy hook's `exclude: ^testing/resources/` pointed at a directory that does not exist; removed.

### One `deep_merge`, one check-group source, module-level imports
- `config.py` had `_deep_merge` (returns a new dict) and `config_merger.py` had `deep_merge` (in place); `api.py` deep-copied its input to defend against the in-place one. There is now one `deep_merge` in `config.py` (in place; every value taken from the override is deep-copied, dicts and lists alike, so the caller's config is never aliased), re-exported from `config_merger`; the `api.py` deepcopy is gone. Tests assert the caller's config is untouched after `validate_message` and after a list override into an existing section. A 3,000-case property test against a reference implementation found 0 mismatches and 0 aliasing for the new function, against aliasing in about 2,070 of 3,000 cases for each of the two old ones.
- The 13-name message-check list was duplicated between `main.py` and `api.py` (in sync today, by luck). `rules_catalog.py` now defines `MESSAGE_CHECKS`, `BRANCH_CHECKS` and `FILES_CHECKS` next to the catalog; both callers use them, and tests pin each set against the catalog. `_get_requested_checks` returns a set (only membership was ever used; rule order comes from the catalog).
- 20 function-level import statements (23 names) are hoisted to module level; the import graph is a DAG and none was needed for a cycle. Eight of them were `import re` on the per-check path, so this is neutral-to-positive for CodSpeed.

### A red CodSpeed job, fixed in passing
`Run benchmarks` has failed on every push since #570, this PR's first run included: `test_invalid_default_config_names_the_file_too` carries `@pytest.mark.benchmark` and creates `.github` with `mkdir()`, and CodSpeed executes a marked test more than once against the same `tmp_path`, so the second execution raised `FileExistsError`. The test measures nothing, so it loses the mark, as two real-git tests in `util_test.py` already had for the same reason. Reproduced locally by calling the test twice on one `tmp_path`.

## Testing
- 953 tests pass (887 before). One pre-existing `chmod 000` test fails locally only because the sandbox runs as root.
- `pre-commit run --all-files` clean.
- Changed-line coverage 100%; `config.py`, `config_merger.py`, `rules_catalog.py` at 100%.
- `coverage debug config` now reports `run_omit: tests/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018xYa7m3qup5wyN5MaXFgf6