### PR TITLE
fix: keep allowed branch types and names as regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ variable that override it (priority: CLI > env > TOML > default). Booleans accep
 | `commit.author_email_pattern` | `"^.+@.+$"` | `--author-email-pattern` | `CCHK_AUTHOR_EMAIL_PATTERN` | Regex the author email must match (CC102, with `--author-email`) |
 | `commit.author_name_pattern` | `""` | `--author-name-pattern` | `CCHK_AUTHOR_NAME_PATTERN` | Regex the author name must match (CC101, with `--author-name`) |
 | `branch.conventional_branch` | `true` | `--conventional-branch` | `CCHK_CONVENTIONAL_BRANCH` | Enforce `<type>/<description>` branch names (CC201) |
-| `branch.allow_branch_types` | `feature, bugfix, hotfix, release, chore, feat, fix, build, ci, docs, perf, refactor, test, style, ai, claude, codex, copilot, cursor, dependabot, renovate` | `--allow-branch-types` | `CCHK_ALLOW_BRANCH_TYPES` | Allowed branch `<type>` prefixes |
-| `branch.allow_branch_names` | `[]` | `--allow-branch-names` | `CCHK_ALLOW_BRANCH_NAMES` | Extra whole branch names allowed besides `main`, `master`, `HEAD`, `PR-*` |
+| `branch.allow_branch_types` | `feature, bugfix, hotfix, release, chore, feat, fix, build, ci, docs, perf, refactor, test, style, ai, claude, codex, copilot, cursor, dependabot, renovate` | `--allow-branch-types` | `CCHK_ALLOW_BRANCH_TYPES` | Allowed branch `<type>` prefixes; each entry is a regex matched against the whole type |
+| `branch.allow_branch_names` | `[]` | `--allow-branch-names` | `CCHK_ALLOW_BRANCH_NAMES` | Extra branch names allowed besides `main`, `master`, `HEAD`, `PR-.+`; each entry is a regex matched against the whole branch name, so `create-pull-request/.+` allows a family of them |
 | `branch.require_rebase_target` | `""` | `--require-rebase-target` | `CCHK_REQUIRE_REBASE_TARGET` | Branch the current branch must be rebased onto (CC202); empty disables |
 | `branch.ignore_authors` | `[]` | `--branch-ignore-authors` | `CCHK_BRANCH_IGNORE_AUTHORS` | Authors whose branches skip the branch checks |
 | `push.allow_force_push` | `true` | — (`--no-force-push` runs the check) | `CCHK_ALLOW_FORCE_PUSH` | Reserved; has no effect today. CC301 runs only with `--no-force-push`, which always rejects a non-fast-forward push |

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -1,11 +1,9 @@
 """Rule builder that creates validation rules from config and catalog."""
 
 from __future__ import annotations
-import re
 import sys
 from typing import Any
 from dataclasses import dataclass, replace
-from functools import lru_cache
 from commit_check.config import ConfigError
 from commit_check.util import format_size, parse_size
 from commit_check.rules_catalog import (
@@ -106,16 +104,6 @@ class ValidationRule:
         if self.ignored:
             result["ignored"] = self.ignored
         return result
-
-
-@lru_cache(maxsize=64)
-def _escaped_alternation(items: tuple[str, ...]) -> str:
-    """``a|b|c`` with each item escaped for a regex.
-
-    Cached on the tuple: the same allowed types are built for every rule
-    set, and escaping twenty names on each build was a measurable cost.
-    """
-    return "|".join(re.escape(item) for item in items)
 
 
 class RuleBuilder:
@@ -613,11 +601,13 @@ class RuleBuilder:
         self, allowed_types: list[str], allowed_names: list[str]
     ) -> str:
         """Build regex for conventional branch names."""
-        types_pattern = _escaped_alternation(tuple(allowed_types))
-        # Every alternative is anchored at both ends so an allowed name matches
-        # the whole branch name, not merely its start ("main-backup" is not
-        # "main"). "PR-.+" is a pattern, the rest are literal names.
+        types_pattern = "|".join(allowed_types)
+        # Configured types and names are regular expressions, as they have
+        # always been: the built-in "PR-.+" is one, and the Action's own
+        # config allows "create-pull-request/.+" that way. Every alternative
+        # is anchored at both ends so a name has to match the whole branch
+        # name, not merely its start ("main-backup" is not "main").
         names_pattern = "|".join(["master", "main", "HEAD", r"PR-.+"])
         if allowed_names:
-            names_pattern += "|" + _escaped_alternation(tuple(allowed_names))
+            names_pattern += "|" + "|".join(allowed_names)
         return rf"^(?:{types_pattern})/.+$|^(?:{names_pattern})$"

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -785,11 +785,20 @@ class TestBranchRegexIsAnchored:
         assert not re.match(_branch_regex(), "feature")
         assert not re.match(_branch_regex(), "feature/")
 
-    def test_literal_names_are_escaped(self):
-        # A dot in a configured name is a dot, not "any character".
-        regex = _branch_regex(allow_branch_names=["rel.1"])
-        assert re.match(regex, "rel.1")
-        assert not re.match(regex, "relx1")
+    def test_a_configured_name_may_be_a_pattern(self):
+        # An entry is a regex, like the built-in "PR-.+": the Action's own
+        # config allows the branches peter-evans/create-pull-request opens
+        # this way (commit-check-action#225).
+        regex = _branch_regex(allow_branch_names=["create-pull-request/.+"])
+        assert re.match(regex, "create-pull-request/update-deps")
+        assert re.match(regex, "create-pull-request/patch")
+        # Still anchored at the end, so the pattern has to cover the name.
+        assert not re.match(regex, "wip-create-pull-request/patch")
+
+    def test_a_configured_type_may_be_a_pattern(self):
+        regex = _branch_regex(allow_branch_types=["renovate.*"])
+        assert re.match(regex, "renovate-bot/pin-deps")
+        assert not re.match(regex, "renovate-bot")
 
 
 class TestConventionalCommitGitPrefixes:


### PR DESCRIPTION
## What

`#569` anchored every alternative of the CC201 regex — the right fix for a real bug, where a branch merely *starting* with an allowed name passed (`main-backup` was accepted as `main`, `develop-x` as `develop`). Alongside the anchoring it also `re.escape`d the configured `allow_branch_types` and `allow_branch_names`, turning values that had always been patterns into literals.

That is a regression, and `commit-check-action`'s own `commit-check.toml` hits it:

```toml
[branch]
require_rebase_target = "origin/main"
allow_branch_names = ["create-pull-request/.+"]
```

It was added in commit-check/commit-check-action#231 so branches opened by `peter-evans/create-pull-request` pass CC201 (commit-check/commit-check-action#225). Escaped, it becomes `create\-pull\-request/\.\+` and can only match a branch literally named `create-pull-request/.+`, so nothing matches it any more.

Reproduced against `main` (`v2.17.0.post…`) with `cchk.toml` holding just that one key:

```console
$ git checkout -B create-pull-request/update-deps
$ commit-check --branch --compact
# v2.17.0                                              -> exit 0
# main                                                 -> [FAIL] CC201 branch: create-pull-request/update-deps, exit 1
```

Every repository that copied that recipe would go red on a CLI upgrade, which would land the moment the Action bumps its pin past 2.17.0.

## Fix

Interpolate the configured types and names as written — as they were before #569 — and keep the anchoring. The built-in `PR-.+` is a pattern for the same reason and was never escaped, so this restores one consistent rule: **an entry is a regex matched against the whole type or branch name**.

- `create-pull-request/update-deps` passes again
- `main-backup`, `master2`, `HEADless`, `develop-x` stay rejected — #569's fix is untouched
- escaping was the reason the alternation needed an `lru_cache`d helper; both go

## Tests

`test_literal_names_are_escaped` asserted the behaviour being reverted and is replaced by two that pin the restored contract:

- `test_a_configured_name_may_be_a_pattern` — `create-pull-request/.+` matches the branches it is meant to, and `wip-create-pull-request/patch` still does not (end anchor holds)
- `test_a_configured_type_may_be_a_pattern` — same for `allow_branch_types`

Full suite: **955 passed**.

## Docs

The README configuration table said "extra whole branch names"; it now says each entry is a regex matched against the whole branch name, with `create-pull-request/.+` as the example. Same for `allow_branch_types`.

README `rev:` pins stay at `v2.17.0` — that is still the latest **published** release on PyPI (2.17.1 is a draft), per AGENTS.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Branch type and branch name filters now support regular-expression patterns matched against the complete value.
  - Existing built-in patterns and full-value matching behavior are preserved.

- **Documentation**
  - Updated the configuration reference with clearer regex guidance.
  - Revised examples to include patterns such as `PR-.+` and `create-pull-request/.+`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->