### PR TITLE
fix: name the setting behind a regex that will not compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,13 +381,20 @@ if you need it.
 |-----------|---------|
 | `0` | Every enforced check passed, or every check was skipped. |
 | `1` | A check failed. This is a verdict on the commit. |
-| `2` | The run could not start: bad usage, a `--rev` that does not resolve, or a config file that is missing, is not valid TOML, or names an unknown rule. Nothing was validated. |
+| `2` | The run could not start: bad usage, a `--rev` that does not resolve, a setting whose regex does not compile, or a config file that is missing, is not valid TOML, or names an unknown rule. Nothing was validated. |
 
 A configuration error names the file, so a broken `.github/cchk.toml` is
 reported as:
 
 ```text
 Error: .github/cchk.toml: Expected ']' at the end of a table declaration (at line 1, column 8)
+```
+
+A setting that can also be given as a flag or a `CCHK_*` variable names
+itself instead of guessing at a file, and echoes the value it could not use:
+
+```text
+Error: [commit] message_pattern is not a valid regex: '^(unclosed' (missing ), unterminated subpattern at position 1)
 ```
 
 Scripts that treat any non-zero exit as a rejected commit keep working. Scripts

--- a/commit_check/config.py
+++ b/commit_check/config.py
@@ -26,7 +26,16 @@ class ConfigError(ValueError):
     The message names the offending file where there is one. The CLI reports
     these as exit code 2, apart from a rejected commit (exit code 1), so a
     wrapper can tell a broken policy from a broken commit.
+
+    ``setting`` names the configuration key at fault, for the keys that can
+    arrive from a CLI flag or a ``CCHK_*`` variable as well as from the file.
+    Naming the file as their source would be a guess, so the message names
+    the setting instead and the CLI leaves the file out.
     """
+
+    def __init__(self, message: str, *, setting: str | None = None) -> None:
+        super().__init__(message)
+        self.setting = setting
 
 
 DEFAULT_CONFIG_PATHS = [

--- a/commit_check/main.py
+++ b/commit_check/main.py
@@ -650,7 +650,12 @@ def main() -> int:
             # The merged dict no longer says which file a setting came from,
             # and ``warn`` has no env or CLI form, so it was the TOML file.
             # An explicit --config is named as the user wrote it; otherwise
-            # say which of the default locations was found.
+            # say which of the default locations was found. A setting that
+            # also has a flag and a CCHK_* variable names itself, and is
+            # left alone: pointing at a file it may not have come from
+            # would send the reader to the wrong place.
+            if e.setting:
+                raise
             source = args.config or find_config_path()
             raise ConfigError(f"{source}: {e}" if source else str(e)) from e
 

--- a/commit_check/rule_builder.py
+++ b/commit_check/rule_builder.py
@@ -108,6 +108,25 @@ class ValidationRule:
         return result
 
 
+def _checked_regex(pattern: str, setting: str) -> str:
+    """*pattern*, once it is known to compile.
+
+    An unusable pattern otherwise fails on its first ``re.match``, deep
+    inside a validator, where main's catch-all prints it as a bare
+    "missing ), unterminated subpattern at position 1" and returns exit
+    code 1 -- the code a rejected commit gets, with nothing to say which of
+    the settings holds the pattern. Compiling it while the rule is built
+    names the setting and makes it a configuration error (exit code 2).
+    """
+    try:
+        re.compile(pattern)
+    except re.error as e:
+        raise ConfigError(
+            f"{setting} is not a valid regex: {pattern!r} ({e})", setting=setting
+        ) from e
+    return pattern
+
+
 @lru_cache(maxsize=64)
 def _escaped_alternation(items: tuple[str, ...]) -> str:
     """``a|b|c`` with each item escaped for a regex.
@@ -334,6 +353,8 @@ class RuleBuilder:
             if catalog_entry.check == "tag":
                 regex = tag_config.get("regex", DEFAULT_TAG_REGEX)
                 regex = regex.strip() if isinstance(regex, str) else DEFAULT_TAG_REGEX
+                if regex:
+                    regex = _checked_regex(regex, "[tag] regex")
                 rules.append(
                     ValidationRule(
                         check=catalog_entry.check,
@@ -410,6 +431,7 @@ class RuleBuilder:
         """
         custom_pattern = self.commit_config.get("message_pattern", "").strip()
         if custom_pattern:
+            custom_pattern = _checked_regex(custom_pattern, "[commit] message_pattern")
             # A team that opted out of Conventional Commits must not be told
             # to follow it: the pattern they chose is the one fact that fixes
             # their message, so the failure names it and links to no spec.
@@ -509,7 +531,9 @@ class RuleBuilder:
         """Build author name or email validation rule."""
         regex = catalog_entry.regex
         if self.commit_config.get(config_key, ""):
-            regex = self.commit_config.get(config_key, "").strip()
+            regex = _checked_regex(
+                self.commit_config.get(config_key, "").strip(), f"[commit] {config_key}"
+            )
 
         return ValidationRule(
             check=catalog_entry.check,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1615,3 +1615,57 @@ class TestWarnLevel:
         assert "unknown rule 'branchh'" in err
         # The merged config no longer knows the file; main() must add it.
         assert f"Error: {cfg}: warn names" in err
+
+
+class TestInvalidUserRegexIsAConfigError:
+    """#570 made exit code 2 mean "the policy is broken, nothing was judged".
+
+    A pattern the user wrote that does not compile is exactly that, and used
+    to come back as exit code 1 with a bare re.error text.
+    """
+
+    def test_message_pattern_names_the_setting_and_exits_two(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text('[commit]\nmessage_pattern = "^(unclosed"\n')
+        monkeypatch.setattr("sys.argv", [CMD, "-m", "--config", str(cfg)])
+        rc = main()
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "[commit] message_pattern is not a valid regex" in err
+        assert "'^(unclosed'" in err
+        assert "unterminated subpattern" in err
+
+    def test_a_pattern_from_a_flag_does_not_blame_the_config_file(
+        self, mocker, capsys, monkeypatch, tmp_path
+    ):
+        # The bad value came from the command line; naming the unrelated
+        # file that is also present would send the reader to the wrong place.
+        mocker.patch("sys.stdin.isatty", return_value=False)
+        mocker.patch("sys.stdin.read", return_value="feat: add x\n")
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text("[commit]\nconventional_commits = true\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            [CMD, "--author-name", "--author-name-pattern", "[", "--config", str(cfg)],
+        )
+        rc = main()
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "[commit] author_name_pattern is not a valid regex" in err
+        assert str(cfg) not in err
+
+    def test_tag_regex_from_a_flag_exits_two(self, capsys, monkeypatch, tmp_path):
+        cfg = tmp_path / "cchk.toml"
+        cfg.write_text("[commit]\nconventional_commits = true\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            [CMD, "--tag", "--tag-regex", "^(unclosed", "--config", str(cfg)],
+        )
+        rc = main()
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "[tag] regex is not a valid regex" in err

--- a/tests/rule_builder_test.py
+++ b/tests/rule_builder_test.py
@@ -1,5 +1,6 @@
 """Tests for commit_check.rule_builder module."""
 
+from commit_check.config import ConfigError
 from commit_check.rule_builder import ValidationRule, RuleBuilder
 from commit_check.rules_catalog import RuleCatalogEntry
 import pytest
@@ -835,3 +836,50 @@ class TestConventionalCommitGitPrefixes:
     )
     def test_author_prose_resembling_a_prefix_is_not_exempt(self, message):
         assert not re.match(self._regex(), message)
+
+
+class TestInvalidUserRegexNamesTheSetting:
+    """A pattern that cannot compile is a broken policy, not a bad commit.
+
+    Left to fail on first use it surfaced through main's catch-all as a bare
+    re.error text under exit code 1 -- the code a rejected commit gets --
+    with nothing to say which setting held it.
+    """
+
+    @pytest.mark.parametrize(
+        ("section", "key", "pattern"),
+        [
+            ("commit", "message_pattern", "^(unclosed"),
+            ("commit", "author_name_pattern", "["),
+            ("commit", "author_email_pattern", "("),
+            ("tag", "regex", "^(unclosed"),
+        ],
+    )
+    def test_the_setting_and_the_pattern_are_both_named(self, section, key, pattern):
+        setting = f"[{section}] {key}"
+        with pytest.raises(ConfigError) as excinfo:
+            RuleBuilder({section: {key: pattern}}).build_all_rules()
+        message = str(excinfo.value)
+        assert setting in message
+        assert repr(pattern) in message
+        # The reason from re itself, so the position is not lost.
+        assert "position" in message
+        assert excinfo.value.setting == setting
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"commit": {"message_pattern": r"^PROJ-\d+: .+"}},
+            {"commit": {"author_name_pattern": r"^\w+ \w+$"}},
+            {"commit": {"author_email_pattern": r"^.+@example\.com$"}},
+            {"tag": {"regex": r"^v\d+\.\d+\.\d+$"}},
+        ],
+    )
+    def test_a_usable_pattern_is_untouched(self, config):
+        assert RuleBuilder(config).build_all_rules()
+
+    def test_an_empty_tag_regex_still_disables_the_match(self):
+        # "" means "do not pattern-match tags", not "compile an empty regex".
+        rules = RuleBuilder({"tag": {"regex": ""}}).build_all_rules()
+        tag_rule = next(r for r in rules if r.check == "tag")
+        assert tag_rule.regex is None


### PR DESCRIPTION
Closes #497.

## Why now

`#570` made exit code `2` mean *"the policy is broken, nothing was judged"* and wrote that contract into the README and `--help`. A regex the user supplied that does not compile is exactly that case, and it was not covered — it came back as exit code `1`, the code a **rejected commit** gets:

```console
$ commit-check --author-name --author-name-pattern='['
Error: unterminated character set at position 0
$ echo $?
1
```

Two things are wrong there. The message does not say which of the settings holds the pattern, and a CI wrapper (or `--format json`) reads a typo'd config as a rejected commit. The pattern only fails on its first `re.match`, deep inside a validator, where `main()`'s catch-all prints the bare text from `re`.

## What changed

The four settings that really are compiled — `[commit] message_pattern`, `[commit] author_name_pattern`, `[commit] author_email_pattern`, `[tag] regex` — are compiled while the rule is built, and a failure is a `ConfigError`, which the CLI already returns as exit code `2`:

```console
$ commit-check --author-name --author-name-pattern='['
Error: [commit] author_name_pattern is not a valid regex: '[' (unterminated character set at position 0)
$ echo $?
2
```

### Not blaming the wrong file

These four can arrive from the config file, a `--flag`, or a `CCHK_*` variable, and the merged dict no longer remembers which. `main()` prefixes a `ConfigError` with the config file it found — correct for `warn`, which has no flag or env form, but a guess here, and a wrong one for a value passed on the command line. `ConfigError` now carries the setting name for that case and `main()` leaves the file out when it is set. The `warn` error still names the file, unchanged.

### Deliberately out of scope

`prohibited_patterns` is matched with `fnmatchcase` (a glob, not a regex) and `require_rebase_target` is stripped of anchors and resolved as a branch name with `git rev-parse`. Neither is ever compiled, so neither is checked.

`allow_branch_types` / `allow_branch_names` are not touched here either: on `main` they are `re.escape`d, so any value compiles. #573 restores them to patterns — once that lands, the same check applies to them and I am happy to add it as a follow-up commit to whichever of the two merges second.

## Tests

+12, full suite **966 passed**.

- `tests/rule_builder_test.py::TestInvalidUserRegexNamesTheSetting` — each of the four settings raises `ConfigError`, naming the setting, echoing the pattern, and keeping `re`'s own reason (so the position survives); valid patterns build; an empty `[tag] regex` still disables the match rather than compiling `""`.
- `tests/main_test.py::TestInvalidUserRegexIsAConfigError` — exit code `2` end to end; a pattern from a flag does **not** name an unrelated config file that happens to exist; `--tag-regex` likewise.

README: the exit-code table now lists "a setting whose regex does not compile" under `2`, with the new message shown.

README `rev:` pins stay at `v2.17.0` — still the latest **published** release on PyPI, per AGENTS.md.
